### PR TITLE
HACK:arm/coproc: Fix device pass through

### DIFF
--- a/xen/arch/arm/domain_build.c
+++ b/xen/arch/arm/domain_build.c
@@ -1332,7 +1332,8 @@ static int handle_node(struct domain *d, struct kernel_info *kinfo,
         return make_timer_node(d, kinfo->fdt, node);
 
 #ifdef CONFIG_HAS_COPROC
-    if ( device_get_class(node) == DEVICE_COPROC )
+    if ( (device_get_class(node) == DEVICE_COPROC) &&
+         (dt_device_used_by(node) == DOMID_XEN) )
     {
         res = handle_coproc_node(d, node);
         if ( res)


### PR DESCRIPTION
The check in this patch seem to be not obvious: needs more attention

If there is a coproc driver in Xen, but device won't be
used as a coproc for this domain, then just pass it as is
in the DTB.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>