### PR TITLE
arm/coproc: Do not pass coproc and domain to vcoproc_init

### DIFF
--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -138,7 +138,7 @@ static struct vcoproc_instance *coproc_init_vcoproc(struct domain *d,
     vcoproc->state = VCOPROC_UNKNOWN;
     spin_lock_init(&vcoproc->lock);
 
-    ret = coproc->ops->vcoproc_init(d, coproc, vcoproc);
+    ret = coproc->ops->vcoproc_init(vcoproc);
     if ( ret )
     {
         printk("Failed to initialize vcoproc_instance for %s\n",

--- a/xen/arch/arm/coproc/coproc.h
+++ b/xen/arch/arm/coproc/coproc.h
@@ -79,8 +79,7 @@ struct coproc_device {
 /* coproc callback functions */
 struct coproc_ops {
     /* callback to perform initialization for the vcoproc instance */
-    int (*vcoproc_init)(struct domain *, struct coproc_device *,
-                        struct vcoproc_instance *);
+    int (*vcoproc_init)(struct vcoproc_instance *);
     /* callback to perform deinitialization for the vcoproc instance */
     void (*vcoproc_deinit)(struct domain *, struct vcoproc_instance *);
     /* callback to perform context switch from the running vcoproc instance */

--- a/xen/arch/arm/coproc/plat/coproc_xxx.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx.c
@@ -94,16 +94,14 @@ static int vcoproc_xxx_ctx_switch_to(struct vcoproc_instance *next)
     return 0;
 }
 
-static int vcoproc_xxx_vcoproc_init(struct domain *d,
-                                    struct coproc_device *coproc,
-                                    struct vcoproc_instance *vcoproc)
+static int vcoproc_xxx_vcoproc_init(struct vcoproc_instance *vcoproc)
 {
     int i;
 
-    for ( i = 0; i < coproc->num_mmios; i++ )
+    for ( i = 0; i < vcoproc->coproc->num_mmios; i++ )
     {
-        struct mmio *mmio = &coproc->mmios[i];
-        register_mmio_handler(d, &vcoproc_xxx_mmio_handler,
+        struct mmio *mmio = &vcoproc->coproc->mmios[i];
+        register_mmio_handler(vcoproc->domain, &vcoproc_xxx_mmio_handler,
                               mmio->addr, mmio->size, mmio);
     }
 


### PR DESCRIPTION
This fixes "arm/coproc: remove coproc from vcoproc_init parameter's list" #23 

vcoproc_instance structure, passed to vcoproc_init,
already has all the data needed for the vcoproc's init code.
Do not pass coproc and domain and get those from
vcoproc_instance structure.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>