### PR TITLE
arm/coproc: Fix vcoproc deinitialization order.

### DIFF
--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -198,10 +198,10 @@ static void coproc_deinit_vcoproc(struct domain *d,
         return;
 
     coproc = vcoproc->coproc;
-    coproc->ops->vcoproc_deinit(d, vcoproc);
     spin_lock(&coproc->vcoprocs_lock);
     list_del(&vcoproc->vcoproc_elem);
     spin_unlock(&coproc->vcoprocs_lock);
+    coproc->ops->vcoproc_deinit(d, vcoproc);
     xfree(vcoproc);
 }
 

--- a/xen/arch/arm/coproc/coproc.h
+++ b/xen/arch/arm/coproc/coproc.h
@@ -126,6 +126,7 @@ struct vcoproc_instance {
     /*
      * this list is used to append this vcoproc
      * to the "domain's" instances list
+     * must not be touched by any of vcoprocs
      */
     struct list_head instance_elem;
 


### PR DESCRIPTION
This fixes "arm/coproc: remove vcoproc from the list prior to deinit" #22 

Currently, we deinitialize a vcoproc and then
remove it from the coproc's list. This may lead to race
conditions as vcoproc_deinit and list manipulation are
not both spin lock protected, but the later.

Fix this by first removing vcoproc from the list
and then deinitializing it. Put a note, that
struct list_head vcoproc_elem must not be touched
by any vcoprocs.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>