### PR TITLE
arm/coproc: Do not pass domain to vcoproc_deinit as parameter

### DIFF
--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -189,8 +189,7 @@ static inline bool_t coproc_is_created_vcoproc(struct domain *d,
     return coproc_get_vcoproc(d, coproc) ? true : false;
 }
 
-static void coproc_deinit_vcoproc(struct domain *d,
-                                  struct vcoproc_instance *vcoproc)
+static void coproc_deinit_vcoproc(struct vcoproc_instance *vcoproc)
 {
     struct coproc_device *coproc;
 
@@ -201,7 +200,7 @@ static void coproc_deinit_vcoproc(struct domain *d,
     spin_lock(&coproc->vcoprocs_lock);
     list_del(&vcoproc->vcoproc_elem);
     spin_unlock(&coproc->vcoprocs_lock);
-    coproc->ops->vcoproc_deinit(d, vcoproc);
+    coproc->ops->vcoproc_deinit(vcoproc);
     xfree(vcoproc);
 }
 
@@ -233,7 +232,7 @@ static int coproc_attach_to_domain(struct domain *d,
     ret = vcoproc_scheduler_vcoproc_init(coproc->sched, vcoproc);
     if ( ret )
     {
-        coproc_deinit_vcoproc(d, vcoproc);
+        coproc_deinit_vcoproc(vcoproc);
         goto out;
     }
 
@@ -287,7 +286,7 @@ static int coproc_detach_from_domain(struct domain *d,
     list_del_init(&vcoproc->instance_elem);
     vcoproc_d->num_instances--;
 
-    coproc_deinit_vcoproc(d, vcoproc);
+    coproc_deinit_vcoproc(vcoproc);
 
     printk("Destroyed vcoproc \"%s\" for dom%u\n",
             dev_path(coproc->dev), d->domain_id);

--- a/xen/arch/arm/coproc/coproc.h
+++ b/xen/arch/arm/coproc/coproc.h
@@ -81,7 +81,7 @@ struct coproc_ops {
     /* callback to perform initialization for the vcoproc instance */
     int (*vcoproc_init)(struct vcoproc_instance *);
     /* callback to perform deinitialization for the vcoproc instance */
-    void (*vcoproc_deinit)(struct domain *, struct vcoproc_instance *);
+    void (*vcoproc_deinit)(struct vcoproc_instance *);
     /* callback to perform context switch from the running vcoproc instance */
     s_time_t (*ctx_switch_from)(struct vcoproc_instance *);
     /* callback to perform context switch to the waiting vcoproc instance */

--- a/xen/arch/arm/coproc/plat/coproc_xxx.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx.c
@@ -108,8 +108,7 @@ static int vcoproc_xxx_vcoproc_init(struct vcoproc_instance *vcoproc)
     return 0;
 }
 
-static void vcoproc_xxx_vcoproc_deinit(struct domain *d,
-                                       struct vcoproc_instance *vcoproc_xxx)
+static void vcoproc_xxx_vcoproc_deinit(struct vcoproc_instance *vcoproc_xxx)
 {
     /* nothing to do */
 }


### PR DESCRIPTION
This fixes "arm/coproc: vcoproc_deinit doesn't need domain as its parameter" #32 

We pass vcoproc_instance to vcoproc_deinit which already
has domain in it, so no need to pass domain
explicitly.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>