### PR TITLE
arm/coproc: Use coproc_release in case of error

### DIFF
--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -339,7 +339,7 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
         printk("Failed to find at least one mmio for \"%s\"\n",
                dev_path(coproc->dev));
         ret = -ENODEV;
-        goto out_free_mmios;
+        goto out;
     }
 
     coproc->mmios = xzalloc_array(struct mmio, num_mmios);
@@ -348,7 +348,7 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
         printk("Failed to allocate %d mmio(s) for \"%s\"\n", num_mmios,
                dev_path(coproc->dev));
         ret = -ENOMEM;
-        goto out_free_mmios;
+        goto out;
     }
 
     for ( i = 0; i < num_mmios; ++i )
@@ -359,7 +359,7 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
         {
             printk("Failed to remap IO for \"%s\"\n", dev_path(coproc->dev));
             ret = PTR_ERR(coproc->mmios[i].base);
-            goto out_iounmap_mmios;
+            goto out;
         }
 
         coproc->mmios[i].size = resource_size(res);
@@ -377,7 +377,7 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
         printk("Failed to find at least one irq for \"%s\"\n",
                dev_path(coproc->dev));
         ret = -ENODEV;
-        goto out_free_irqs;
+        goto out;
     }
 
     coproc->irqs = xzalloc_array(unsigned int, num_irqs);
@@ -386,7 +386,7 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
         printk("Failed to allocate %d irq(s) for \"%s\"\n", num_irqs,
                dev_path(coproc->dev));
         ret = -ENOMEM;
-        goto out_free_irqs;
+        goto out;
     }
 
     for ( i = 0; i < num_irqs; ++i )
@@ -398,7 +398,7 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
             printk("Failed to get irq index %d for \"%s\"\n", i,
                    dev_path(coproc->dev));
             ret = -ENODEV;
-            goto out_free_irqs;
+            goto out;
         }
         coproc->irqs[i] = irq;
     }
@@ -410,18 +410,8 @@ struct coproc_device *coproc_alloc(struct platform_device *pdev,
 
     return coproc;
 
-out_free_irqs:
-    xfree(coproc->irqs);
-out_iounmap_mmios:
-    for ( i = 0; i < num_mmios; ++i )
-    {
-        if ( !IS_ERR(coproc->mmios[i].base) )
-            iounmap(coproc->mmios[i].base);
-    }
-out_free_mmios:
-    xfree(coproc->mmios);
-    xfree(coproc);
-
+out:
+    coproc_release(coproc);
     return ERR_PTR(ret);
 }
 
@@ -432,7 +422,7 @@ void coproc_release(struct coproc_device *coproc)
     if ( IS_ERR_OR_NULL(coproc) )
         return;
     xfree(coproc->irqs);
-    for ( i = 0; i < coproc->num_mmios; ++i )
+    for ( i = 0; i < coproc->num_mmios; i++ )
     {
         if ( !IS_ERR_OR_NULL(coproc->mmios[i].base) )
             iounmap(coproc->mmios[i].base);


### PR DESCRIPTION
This fixes "arm/coproc: re-work cleanup paths" #26 

Use coproc_release if coproc allocation fails.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>