### PR TITLE
arm/coproc: Fix misspeled scheduler

### DIFF
--- a/xen/arch/arm/coproc/plat/coproc_xxx.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx.c
@@ -68,9 +68,9 @@ static int vcoproc_xxx_write(struct vcpu *v, mmio_info_t *info, register_t r,
             vgic_vcpu_inject_spi(ctx.vcoproc->domain, ctx.coproc->irqs[i]);
 
         if ( r & CORPOC_XXX_ENABLE )
-            vcoproc_sheduler_vcoproc_wake(ctx.coproc->sched, ctx.vcoproc);
+            vcoproc_scheduler_vcoproc_wake(ctx.coproc->sched, ctx.vcoproc);
         else
-            vcoproc_sheduler_vcoproc_sleep(ctx.coproc->sched, ctx.vcoproc);
+            vcoproc_scheduler_vcoproc_sleep(ctx.coproc->sched, ctx.vcoproc);
     }
 #endif
 

--- a/xen/arch/arm/coproc/schedule.c
+++ b/xen/arch/arm/coproc/schedule.c
@@ -96,7 +96,7 @@ int vcoproc_scheduler_vcoproc_destroy(struct vcoproc_scheduler *sched,
     if ( vcoproc_scheduler_vcoproc_is_destroyed(sched, vcoproc) )
         return 0;
 
-    vcoproc_sheduler_vcoproc_sleep(sched, vcoproc);
+    vcoproc_scheduler_vcoproc_sleep(sched, vcoproc);
 
     spin_lock_irqsave(&sched_data->schedule_lock, flags);
     if ( vcoproc->state == VCOPROC_ASKED_TO_SLEEP )
@@ -116,7 +116,7 @@ int vcoproc_scheduler_vcoproc_destroy(struct vcoproc_scheduler *sched,
     return 0;
 }
 
-void vcoproc_sheduler_vcoproc_wake(struct vcoproc_scheduler *sched,
+void vcoproc_scheduler_vcoproc_wake(struct vcoproc_scheduler *sched,
                                    struct vcoproc_instance *vcoproc)
 {
     struct vcoproc_schedule_data *sched_data = sched->sched_priv;
@@ -139,7 +139,7 @@ void vcoproc_sheduler_vcoproc_wake(struct vcoproc_scheduler *sched,
     vcoproc_schedule(sched);
 }
 
-void vcoproc_sheduler_vcoproc_sleep(struct vcoproc_scheduler *sched,
+void vcoproc_scheduler_vcoproc_sleep(struct vcoproc_scheduler *sched,
                                     struct vcoproc_instance *vcoproc)
 {
     struct vcoproc_schedule_data *sched_data = sched->sched_priv;
@@ -170,7 +170,7 @@ void vcoproc_sheduler_vcoproc_sleep(struct vcoproc_scheduler *sched,
         vcoproc_schedule(sched);
 }
 
-void vcoproc_sheduler_vcoproc_yield(struct vcoproc_scheduler *sched,
+void vcoproc_scheduler_vcoproc_yield(struct vcoproc_scheduler *sched,
                                     struct vcoproc_instance *vcoproc)
 {
     struct vcoproc_schedule_data *sched_data = sched->sched_priv;

--- a/xen/arch/arm/coproc/schedule.h
+++ b/xen/arch/arm/coproc/schedule.h
@@ -96,11 +96,11 @@ int vcoproc_scheduler_vcoproc_init(struct vcoproc_scheduler *,
 int vcoproc_scheduler_vcoproc_destroy(struct vcoproc_scheduler *,
                                       struct vcoproc_instance *);
 void vcoproc_schedule(struct vcoproc_scheduler *);
-void vcoproc_sheduler_vcoproc_wake(struct vcoproc_scheduler *,
+void vcoproc_scheduler_vcoproc_wake(struct vcoproc_scheduler *,
                                    struct vcoproc_instance *);
-void vcoproc_sheduler_vcoproc_sleep(struct vcoproc_scheduler *,
+void vcoproc_scheduler_vcoproc_sleep(struct vcoproc_scheduler *,
                                     struct vcoproc_instance *);
-void vcoproc_sheduler_vcoproc_yield(struct vcoproc_scheduler *,
+void vcoproc_scheduler_vcoproc_yield(struct vcoproc_scheduler *,
                                     struct vcoproc_instance *);
 
 #endif /* __ARCH_ARM_COPROC_SCHEDULE_H_ */


### PR DESCRIPTION
This fixes "Rename vcoproc_sheduler_xxx to vcoproc_scheduler_xxx" #17 
Rename vcoproc_sheduler_xxx to vcoproc_scheduler_xxx.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>