### PR TITLE
arm/coproc: Fix: coproc_get_vcoproc must disable interrupts

### DIFF
--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -115,8 +115,9 @@ struct vcoproc_instance *coproc_get_vcoproc(struct domain *d,
 {
     struct vcoproc_instance *vcoproc = NULL;
     bool_t found = false;
+    unsigned long flags;
 
-    spin_lock(&coproc->vcoprocs_lock);
+    spin_lock_irqsave(&coproc->vcoprocs_lock, flags);
 
     if ( list_empty(&coproc->vcoprocs) )
         goto out;
@@ -131,7 +132,7 @@ struct vcoproc_instance *coproc_get_vcoproc(struct domain *d,
     }
 
 out:
-    spin_unlock(&coproc->vcoprocs_lock);
+    spin_unlock_irqrestore(&coproc->vcoprocs_lock, flags);
 
     return found ? vcoproc : NULL;
 }


### PR DESCRIPTION
coproc_get_vcoproc gets called from MMIO handlers which
code works at the same time as interrupts served.
A deadlock possible when handler is entered, spin lock
acquired and at that same time IRQ is also about to get
locked.
Use spin_lock_irqsave/irqrestore so the race is correctly
handled.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>