### PR TITLE
SCF: implement different debug levels for coprocs

### DIFF
--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -573,12 +573,22 @@ int __init coproc_register(struct coproc_device *coproc)
     return 0;
 }
 
-bool_t coproc_debug = true;
+int coproc_debug = COPROC_DBG_ERROR;
 
 void coproc_debug_toggle(unsigned char key)
 {
-    coproc_debug = !coproc_debug;
-    printk("coproc debug is %s\n", coproc_debug ? "enabled" : "disabled");
+    if ( key == 'c' )
+    {
+        /* FIXME: this corresponds to XENLOG_DEBUG */
+        if ( coproc_debug < COPROC_DBG_LAST )
+            coproc_debug++;
+    }
+    else
+    {
+        if ( coproc_debug > 0 )
+            coproc_debug--;
+    }
+    printk("coproc debug level is %d\n", coproc_debug);
 }
 
 void __init coproc_init(void)
@@ -587,7 +597,10 @@ void __init coproc_init(void)
     unsigned int num_coprocs = 0;
     int ret;
 
-    register_keyhandler('c', coproc_debug_toggle, "toggle debug for coproc", 0);
+    register_keyhandler('c', coproc_debug_toggle,
+                        "increase debug level for coproc", 0);
+    register_keyhandler('v', coproc_debug_toggle,
+                        "decrease debug level for coproc", 0);
 
     /*
      * For the moment, we'll create coproc for each device that presents

--- a/xen/arch/arm/coproc/coproc.h
+++ b/xen/arch/arm/coproc/coproc.h
@@ -136,6 +136,44 @@ struct vcoproc_instance {
     void *priv;
 };
 
+/* coproc logger functions */
+
+extern int coproc_debug;
+
+#define coproc_dev_print(dev, lvl, coproc_lvl, fmt, ...)                       \
+do                                                                             \
+{                                                                              \
+    if ( coproc_lvl <= coproc_debug )                                          \
+        printk(lvl "coproc: %s: " fmt,                                         \
+               dev ? dt_node_full_name(dev_to_dt(dev)) : "",                   \
+               ## __VA_ARGS__);                                                \
+} while (0)
+
+/*
+ * this is defined for convenience so we don't have to translate
+ * XENLOG_XXX into corresponding numbers at runtime
+ */
+enum COPROC_DBG_LEVEL
+{
+    COPROC_DBG_ERROR,
+    COPROC_DBG_WARN,
+    COPROC_DBG_INFO,
+    COPROC_DBG_DEBUG,
+    COPROC_DBG_VERB,
+    COPROC_DBG_LAST
+};
+
+#define COPROC_ERROR(dev, fmt, ...)                                            \
+    coproc_dev_print(dev, XENLOG_ERR,     COPROC_DBG_ERROR, fmt, ## __VA_ARGS__)
+#define COPROC_WARN(dev, fmt, ...)                                             \
+    coproc_dev_print(dev, XENLOG_WARNING, COPROC_DBG_WARN, fmt, ## __VA_ARGS__)
+#define COPROC_NOTE(dev, fmt, ...)                                             \
+    coproc_dev_print(dev, XENLOG_INFO,    COPROC_DBG_INFO, fmt, ## __VA_ARGS__)
+#define COPROC_DEBUG(dev, fmt, ...)                                            \
+    coproc_dev_print(dev, XENLOG_DEBUG,   COPROC_DBG_DEBUG, fmt, ## __VA_ARGS__)
+#define COPROC_VERBOSE(dev, fmt, ...)                                            \
+    coproc_dev_print(dev, XENLOG_DEBUG,   COPROC_DBG_VERB, fmt, ## __VA_ARGS__)
+
 void coproc_init(void);
 struct coproc_device * coproc_alloc(struct dt_device_node *,
                                     const struct coproc_ops *);

--- a/xen/arch/arm/coproc/plat/common.h
+++ b/xen/arch/arm/coproc/plat/common.h
@@ -133,15 +133,6 @@ COPROC_REG_HELPERS(32, 0x3);
 
 #undef COPROC_REG_HELPERS
 
-/* Device logger functions */
-#define dev_print(dev, lvl, fmt, ...) \
-    printk(lvl "coproc: %s: " fmt, dt_node_full_name(dev_to_dt(dev)), ## __VA_ARGS__)
-
-#define dev_dbg(dev, fmt, ...) dev_print(dev, XENLOG_DEBUG, fmt, ## __VA_ARGS__)
-#define dev_notice(dev, fmt, ...) dev_print(dev, XENLOG_INFO, fmt, ## __VA_ARGS__)
-#define dev_warn(dev, fmt, ...) dev_print(dev, XENLOG_WARNING, fmt, ## __VA_ARGS__)
-#define dev_err(dev, fmt, ...) dev_print(dev, XENLOG_ERR, fmt, ## __VA_ARGS__)
-
 #endif /* __ARCH_ARM_COPROC_PLAT_COMMON_H__ */
 
 /*

--- a/xen/arch/arm/coproc/plat/coproc_xxx.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx.c
@@ -38,8 +38,9 @@ static int vcoproc_xxx_read(struct vcpu *v, mmio_info_t *info, register_t *r,
     struct vcoproc_rw_context ctx;
 
     vcoproc_get_rw_context(v->domain, mmio, info, &ctx);
-    dev_dbg(ctx.coproc->dev, "read r%d=%"PRIregister" offset %#08x base %#08x\n",
-            ctx.dabt.reg, *r, ctx.offset, (uint32_t)mmio->addr);
+    COPROC_DEBUG(ctx.coproc->dev,
+                 "read r%d=%"PRIregister" offset %#08x base %#08x\n",
+                 ctx.dabt.reg, *r, ctx.offset, (uint32_t)mmio->addr);
 
     return 1;
 }
@@ -51,8 +52,9 @@ static int vcoproc_xxx_write(struct vcpu *v, mmio_info_t *info, register_t r,
     struct vcoproc_rw_context ctx;
 
     vcoproc_get_rw_context(v->domain, mmio, info, &ctx);
-    dev_dbg(ctx.coproc->dev, "write r%d=%"PRIregister" offset %#08x base %#08x\n",
-            ctx.dabt.reg, r, ctx.offset, (uint32_t)mmio->addr);
+    COPROC_DEBUG(ctx.coproc->dev,
+                 "write r%d=%"PRIregister" offset %#08x base %#08x\n",
+                 ctx.dabt.reg, r, ctx.offset, (uint32_t)mmio->addr);
 
 #if 1
     /* for debug purposes */
@@ -147,7 +149,8 @@ static int coproc_xxx_dt_probe(struct dt_device_node *np)
                          coproc_xxx);
         if ( ret )
         {
-            dev_err(dev, "failed to request irq %d (%u)\n", i, coproc_xxx->irqs[i]);
+            COPROC_ERROR(dev, "failed to request irq %d (%u)\n", i,
+                         coproc_xxx->irqs[i]);
             goto out_release_irqs;
         }
     }
@@ -155,7 +158,7 @@ static int coproc_xxx_dt_probe(struct dt_device_node *np)
     ret = coproc_register(coproc_xxx);
     if ( ret )
     {
-        dev_err(dev, "failed to register coproc (%d)\n", ret);
+        COPROC_DEBUG(dev, "failed to register coproc (%d)\n", ret);
         goto out_release_irqs;
     }
 

--- a/xen/arch/arm/coproc/schedule.c
+++ b/xen/arch/arm/coproc/schedule.c
@@ -190,42 +190,37 @@ void vcoproc_scheduler_vcoproc_yield(struct vcoproc_scheduler *sched,
     vcoproc_schedule(sched);
 }
 
-extern bool_t coproc_debug;
-
 static inline void schedule_trace(struct vcoproc_instance *curr,
                                   struct vcoproc_instance *next,
                                   int stage)
 {
-    if ( !coproc_debug )
-        return;
-
     switch ( stage )
     {
     case 0:
-        printk("----------NOTHING TO SCHEDULE-----------------------\n");
+        COPROC_VERBOSE(NULL, "--NOTHING TO SCHEDULE--------------------\n");
         break;
 
     case 1:
-        printk("----------dom %d (%s) CONTINUE RUNNING (BUSY)------------\n",
-               curr ? curr->domain->domain_id : -1,
-               curr ? dev_path(curr->coproc->dev) : "NULL");
+        COPROC_VERBOSE(NULL, "--dom %d (%s) CONTINUE RUNNING (BUSY)----\n",
+                       curr ? curr->domain->domain_id : -1,
+                       curr ? dev_path(curr->coproc->dev) : "NULL");
         break;
 
     case 2:
-        printk("----------dom %d (%s) CONTINUE RUNNING (SINGLE)----------\n",
-               curr ? curr->domain->domain_id : -1,
-               curr ? dev_path(curr->coproc->dev) : "NULL");
+        COPROC_VERBOSE(NULL, "--dom %d (%s) CONTINUE RUNNING (SINGLE)--\n",
+                       curr ? curr->domain->domain_id : -1,
+                       curr ? dev_path(curr->coproc->dev) : "NULL");
         break;
 
     case 3:
         if (next)
-            printk("----------dom %d (%s) START RUNNING----------------------\n",
-                   next ? next->domain->domain_id : -1,
-                   next ? dev_path(next->coproc->dev) : "NULL");
+            COPROC_VERBOSE(NULL, "--dom %d (%s) START RUNNING--------------\n",
+                           next ? next->domain->domain_id : -1,
+                           next ? dev_path(next->coproc->dev) : "NULL");
         else
-            printk("----------dom %d (%s )STOP RUNNING-----------------------\n",
-                   curr ? curr->domain->domain_id : -1,
-                   curr ? dev_path(curr->coproc->dev) : "NULL");
+            COPROC_VERBOSE(NULL, "--dom %d (%s )STOP RUNNING---------------\n",
+                           curr ? curr->domain->domain_id : -1,
+                           curr ? dev_path(curr->coproc->dev) : "NULL");
         break;
 
     default:


### PR DESCRIPTION
This allows better control on verbosity ob the debug
messages via debug levels, not binary choice
of on/off.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>