### PR TITLE
scf: fix coproc debug printing

### DIFF
--- a/xen/arch/arm/coproc/coproc.h
+++ b/xen/arch/arm/coproc/coproc.h
@@ -145,7 +145,7 @@ do                                                                             \
 {                                                                              \
     if ( coproc_lvl <= coproc_debug )                                          \
         printk(lvl "coproc: %s: " fmt,                                         \
-               dev ? dt_node_full_name(dev_to_dt(dev)) : "",                   \
+               (dev) ? dt_node_full_name(dev_to_dt(dev)) : "",                 \
                ## __VA_ARGS__);                                                \
 } while (0)
 


### PR DESCRIPTION
Wrap the dev with bracers to be able to pass a conditional operator inside.