### PR TITLE
SCF rework

### DIFF
--- a/docs/misc/arm/device-tree/scf.txt
+++ b/docs/misc/arm/device-tree/scf.txt
@@ -1,0 +1,16 @@
+Shared coprocessor framework configuration
+==========================================
+
+Any device with the property "xen,coproc" set will be owned by SCF and will not
+be directly exposed to Dom0. "xen,coproc" property is only meaningful for a
+system device tree which is passed to XEN.
+
+Any device with the property "xen,vcoproc" will be processed by SCF to create
+a virtual coprocessor. If succeed, the device will be injected in the domain's
+device tree with that property wiped. The property value is a stringified path
+or an alias (from a system device tree)  of a physical coproc device the virtual
+coprocessor will run on. That physical coprocessor device node has to be marked
+with "xen,coproc" property.
+"xen,vcoproc" property is meaningful for both a system device tree and DomU's
+partial device trees.
+

--- a/docs/misc/arm/scf.txt
+++ b/docs/misc/arm/scf.txt
@@ -1,0 +1,241 @@
+Share a coprocessor to several domains using guest's Device Tree
+================================================================
+
+This example will configure two dummy coprocessors and correspondent virtual
+coprocessors and is based on an RCar Gen3 device tree already adjusted for Dom0.
+Some free iomem range not assigned to any real device will be used for a dummy
+coprocessors definition. One dummy coprocessor would have a single iomem range
+and one irq. Another one will have several named iomem ranges and irqs.
+Two virtual instances of each coprocessor will be configured for Dom0 using a
+system device tree and other two will be configured for DomU using a partial
+device tree.
+
+Let us have two dummy coprocessors defined as following:
+
+\ {
+	...
+	aliases {
+		...
+		pcoproc0 = &coproc0;
+		pcoproc1 = &coproc1;
+		...
+	};
+	...
+	soc {
+		...
+		coproc0: pcoproc0@0xe6110000 {
+			compatible = "vendor_xxx,coproc_xxx";
+			reg = <0x0 0xe6110000 0x0 0x1000>;
+			interrupts = <GIC_SPI 160 IRQ_TYPE_LEVEL_HIGH>;
+			status = "okay";
+		};
+
+		coproc1: pcoproc1@0xe6182000 {
+			compatible = "vendor_xxx,coproc_xxc";
+			reg = <0x0 0xe6182000 0x0 0x1000>,
+			      <0x0 0xe6184000 0x0 0x1000>,
+			      <0x0 0xe6188000 0x0 0x8000>;
+			reg-names = "op", "mmu", "sram";
+			interrupts = <GIC_SPI 132 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 135 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "op", "mmu";
+			status = "okay";
+		};
+
+		...
+	};
+	...
+};
+
+Notes:
+    * If a coprocessor has several iomem ranges they must be named. Same for
+      interrupts. Names are used for matching both for shared coprocessor
+      platform code probe as well as mapping virtual coprocessors into domains.
+
+1) Mark the coprocessor node to let Xen know it will be used for sharing.
+This is done in the device tree node describing the device by adding the
+property "xen,coproc".
+
+\ {
+	...
+	aliases {
+		...
+		pcoproc0 = &coproc0;
+		pcoproc1 = &coproc1;
+		...
+	};
+	...
+	soc {
+		...
+		coproc0: pcoproc0@0xe6110000 {
+			compatible = "vendor_xxx,coproc_xxx";
+			reg = <0x0 0xe6110000 0x0 0x1000>;
+			interrupts = <GIC_SPI 160 IRQ_TYPE_LEVEL_HIGH>;
+			status = "okay";
++			xen,coproc;
+		};
+
+		coproc1: pcoproc1@0xe6182000 {
+			compatible = "vendor_xxx,coproc_xxc";
+			reg = <0x0 0xe6182000 0x0 0x1000>,
+			      <0x0 0xe6184000 0x0 0x1000>,
+			      <0x0 0xe6188000 0x0 0x8000>;
+			reg-names = "op", "mmu", "sram";
+			interrupts = <GIC_SPI 132 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 135 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "op", "mmu";
+			status = "okay";
++			xen,coproc;
+		};
+		...
+	};
+	...
+};
+
+2) Create virtual coprocessors nodes. Virtual coprocessor nodes should contain a
+property "xen,vcoproc". The value of this property is a string which reflects a
+full name of a physical coproc node or an alias valid within a system's device
+tree.
+For vcoproc's MMIOs you should find holes of suitable size in a domain memory
+layout. For the first instance of the virtual coprocessor in a domain you freely
+can use MMIO ranges same as a correspondent physical coprocessor uses.
+A virtual coprocessor in a domain will be using the same IRQ(s) as the
+physical coprocessor uses. If several virtual coprocessors baked by one physical
+coprocessor are provided to a domain, they will share the same IRQ(s). 
+
+\ {
+	...
+	aliases {
+		...
+		pcoproc0 = &coproc0;
+		pcoproc1 = &coproc1;
+		...
+	};
+	...
+	soc {
+		...
+		coproc0: pcoproc0@0xe6110000 {
+			compatible = "vendor_xxx,coproc_xxx";
+			reg = <0x0 0xe6110000 0x0 0x1000>;
+			interrupts = <GIC_SPI 160 IRQ_TYPE_LEVEL_HIGH>;
+			status = "okay";
+			xen,coproc;
+		};
++
++		coproc0@e6110000 {
++			reg = <0x0 0xe6110000 0x0 0x1000>;
++			/* reference a pcoproc by a full node name */
++			xen,vcoproc = "/soc/pcoproc0@0xe6110000";
++		};
++		coproc0@e6114000 {
++			/* reference a pcoproc by an alias */
++			reg = <0x0 0xe6114000 0x0 0x1000>;
++			xen,vcoproc = "pcoproc0";
++		};
+
+		coproc1: pcoproc1@0xe6182000 {
+			compatible = "vendor_xxx,coproc_xxc";
+			reg = <0x0 0xe6182000 0x0 0x1000>,
+			      <0x0 0xe6184000 0x0 0x1000>,
+			      <0x0 0xe6188000 0x0 0x8000>;
+			reg-names = "op", "mmu", "sram";
+			interrupts = <GIC_SPI 132 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 135 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "op", "mmu";
+			status = "okay";
+			xen,coproc;
+		};
+
++		coproc1@0xe6182000 {
++			reg = <0x0 0xe6182000 0x0 0x1000>,
++			      <0x0 0xe6184000 0x0 0x1000>,
++			      <0x0 0xe6188000 0x0 0x8000>;
++			reg-names = "op", "mmu", "sram";
++			xen,vcoproc = "/soc/pcoproc1@0xe6182000";
++		};
++
++		coproc1@0xe619a000 {
++			reg = <0x0 0xe619a000 0x0 0x1000>,
++			      <0x0 0xe6152000 0x0 0x1000>,
++			      <0x0 0xe6058000 0x0 0x8000>;
++			reg-names = "op", "mmu", "sram";
++			xen,vcoproc = "pcoproc1";
+
+		...
+	};
+	...
+};
+
+Notes:
+    * As you could notice virtual coprocessor "coproc1@0xe619a000" has its iomem
+      ranges mapped to arbitrary addresses, their relative offsets are not kept.
+      This does not take us into issues because range name matching is used.
+
+2) Create a partial device tree describing a virtual coprocessors provided to
+DomU:
+
+/dts-v1/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+    /* #*cells are here to keep DTC happy */
+    #address-cells = <2>;
+    #size-cells = <2>;
+
+	soc {
+		compatible = "simple-bus";
+		ranges;
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		coproc0@e6110000 {
+			xen,vcoproc = "/soc/pcoproc0@0xe6110000";
+			compatible = "vendor_xxx,coproc_xxx";
+			reg = <0x0 0xe6110000 0x0 0x1000>;
+			interrupts = <GIC_SPI 160 IRQ_TYPE_LEVEL_HIGH>;
+			status = "okay";
+		};
+		coproc0@e6114000 {
+			xen,vcoproc = "pcoproc0";
+			compatible = "vendor_xxx,coproc_xxx";
+			reg = <0x0 0xe6114000 0x0 0x1000>;
+			interrupts = <GIC_SPI 160 IRQ_TYPE_LEVEL_HIGH>;
+			status = "okay";
+		};
+		coproc1@0xe6182000 {
+			reg = <0x0 0xe6182000 0x0 0x1000>,
+				  <0x0 0xe6184000 0x0 0x1000>,
+				  <0x0 0xe6188000 0x0 0x8000>;
+			reg-names = "op", "mmu", "sram";
+			xen,vcoproc = "/soc/pcoproc1@0xe6182000";
+		};
+
+		coproc1@0xe619a000 {
+			reg = <0x0 0xe619a000 0x0 0x1000>,
+				  <0x0 0xe6152000 0x0 0x1000>,
+				  <0x0 0xe6058000 0x0 0x8000>;
+			reg-names = "op", "mmu", "sram";
+			xen,vcoproc = "pcoproc1";
+	};
+};
+
+Notes:
+    * For a Dom0 device tree in vcoproc nodes you should specify only properties
+      you would like to override, other properties would be taken from physical
+      coprocessor node.
+    * In a DomU partial device tree you should provide all needed properties for
+      virtual coprocessor node which you need in a DomU device tree.
+
+3) Compile the partial guest device with dtc (Device Tree Compiler).
+For our purpose, the compiled file will be called domd-0.dtb and
+placed in /xen/ in Dom0.
+
+3) Specify a partial device tree in a DomU configuration file:
+
+device_tree = "/xen/domd-0.dts"
+
+4) Nothing else should be specified in a domain configuration file. All SCF
+configuration is described in a system device-tree and partial device tree.
+
+

--- a/tools/libxc/include/xenctrl.h
+++ b/tools/libxc/include/xenctrl.h
@@ -1258,7 +1258,8 @@ int xc_domain_soft_reset(xc_interface *xch,
 
 int xc_attach_coproc(xc_interface *xch,
                      uint32_t domid,
-                     char *path);
+                     void *fdt,
+                     int size);
 
 #if defined(__i386__) || defined(__x86_64__)
 /*

--- a/tools/libxc/xc_domain.c
+++ b/tools/libxc/xc_domain.c
@@ -2524,25 +2524,25 @@ int xc_domain_soft_reset(xc_interface *xch,
 int xc_attach_coproc(
     xc_interface *xch,
     uint32_t domid,
-    char *path)
+    void *fdt,
+    int size)
 {
     int rc;
-    size_t size = strlen(path);
     DECLARE_DOMCTL;
-    DECLARE_HYPERCALL_BOUNCE(path, size, XC_HYPERCALL_BUFFER_BOUNCE_IN);
+    DECLARE_HYPERCALL_BOUNCE(fdt, size, XC_HYPERCALL_BUFFER_BOUNCE_IN);
 
-    if ( xc_hypercall_bounce_pre(xch, path) )
+    if ( xc_hypercall_bounce_pre(xch, fdt) )
         return -1;
 
-    domctl.cmd = XEN_DOMCTL_attach_coproc;
+    domctl.cmd = XEN_DOMCTL_browse_pfdt;
     domctl.domain = (domid_t)domid;
 
     domctl.u.attach_coproc.size = size;
-    set_xen_guest_handle(domctl.u.attach_coproc.path, path);
+    set_xen_guest_handle(domctl.u.attach_coproc.fdt, fdt);
 
     rc = do_domctl(xch, &domctl);
 
-    xc_hypercall_bounce_post(xch, path);
+    xc_hypercall_bounce_post(xch, fdt);
 
     return rc;
 }

--- a/xen/arch/arm/coproc/coproc.c
+++ b/xen/arch/arm/coproc/coproc.c
@@ -22,6 +22,7 @@
 #include <xen/guest_access.h>
 #include <xen/keyhandler.h>
 #include <xen/vmap.h>
+#include <xen/libfdt/libfdt.h>
 
 #include "coproc.h"
 
@@ -349,6 +350,27 @@ int vcoproc_handle_node(struct domain *d, void *fdt,
     return ret;
 }
 
+static int vcoproc_browse_node(struct domain *d,
+                               const struct dt_device_node *node)
+{
+    struct dt_device_node *child;
+    int ret;
+
+    if ( dt_device_is_vcoproc(node) )
+    {
+        return vcoproc_handle_node(d, NULL, node);
+    }
+
+    for ( child = node->child; child != NULL; child = child->sibling )
+    {
+        ret = vcoproc_browse_node(d, child);
+        if ( ret )
+            return ret;
+    }
+
+    return 0;
+}
+
 static int vcoproc_eliminate(struct domain *d,
                              struct vcoproc_instance *vcoproc)
 {
@@ -649,34 +671,54 @@ int coproc_release_vcoprocs(struct domain *d)
 int coproc_do_domctl(struct xen_domctl *domctl, struct domain *d,
                      XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
 {
-    char *path;
+    void *fdt, *raw;
     int ret = 0;
+    struct dt_device_node *pdt;
 
     switch ( domctl->cmd )
     {
-    case XEN_DOMCTL_attach_coproc:
+    case XEN_DOMCTL_browse_pfdt:
         if ( unlikely(d->is_dying) )
         {
             ret = -EINVAL;
             break;
         }
 
-        path = safe_copy_string_from_guest(domctl->u.attach_coproc.path,
-                                           domctl->u.attach_coproc.size,
-                                           PAGE_SIZE);
-        if ( IS_ERR(path) )
+        fdt = xmalloc_bytes(domctl->u.attach_coproc.size);
+
+        if ( !fdt )
         {
-            ret = PTR_ERR(path);
+            ret = -ENOMEM;
             break;
         }
 
-        printk("Got coproc \"%s\" for dom%u\n", path, d->domain_id);
+        ret = copy_from_guest(fdt, domctl->u.attach_coproc.fdt,
+                              domctl->u.attach_coproc.size);
 
-//        ret = coproc_find_and_attach_to_domain(d, path);
         if ( ret )
-            printk("Failed to attach coproc \"%s\" to dom%u (%d)\n",
-                   path, d->domain_id, ret);
-        xfree(path);
+        {
+            xfree(fdt);
+            break;
+        }
+
+        dprintk(XENLOG_INFO, "Got pfdt with size %u for dom%u\n",
+                domctl->u.attach_coproc.size, d->domain_id);
+
+        raw = dt_unflatten_device_tree(fdt, &pdt);
+
+        if ( raw )
+        {
+            ret = vcoproc_browse_node(d, pdt);
+            if ( ret )
+                printk("Failed to attach vcoprocs from pfdt to dom%u (%d)\n",
+                       d->domain_id, ret);
+            xfree(raw);
+        }
+        else
+            ret = -ENOMEM;
+
+        xfree(fdt);
+
         break;
 
     default:

--- a/xen/arch/arm/coproc/coproc.h
+++ b/xen/arch/arm/coproc/coproc.h
@@ -29,28 +29,124 @@
 
 #include "schedule.h"
 
-/* coproc memory range */
-struct mmio {
-    u64 addr;
-    u64 size;
-    /* ioremapped addr */
-    void __iomem *base;
+/*
+ * In fields and function names following prefixes mean:
+ * - [p] Platform specific. Means coprocessor IP specific stuff.
+ * - [m] Machine specific. Means some stuff specific to a SoC which integrates
+ *       a coprocessor.
+ * - [v] Virtual. Means a virtual coprocessor related stuff.
+ */
 
-    struct coproc_device *coproc;
+/*
+ * Coprocessor platform memory mapped IO range description
+ *
+ * This is a structure what describes one particular mmio range of a
+ * coprocessor IP block.
+ * This description expected to be common for different SoCs which could
+ * integrate this particular coprocessor IP.
+ * This structure is used as static with following fields initialized at the
+ * compilation time:
+ *     name - to find in DT, ignored if a coproc has only one mmio range
+ *     size - >0 for sanity check, =0 - no sanity check needed, filled from DT
+ *               (f.e. for SRAM bank)
+ *     ops  - IO registers access emulation (r/w) handlers
+ */
+struct pcoproc_mmio {
+    const char *name;
+    u64 size;
+    struct mmio_handler_ops *ops;
 };
 
-/* coproc device that represents the real remote processor */
-struct coproc_device {
+/*
+ * Coprocessor platform IRQ description
+ *
+ * This is a structure what describes one particular IRQ of a coprocessor IP
+ * block. This description is expected to be common for different SoCs which
+ * could integrate this particular coprocessor IP.
+ * This structure is used as static with following fields initialized at the
+ * compilation time:
+ *     name - to find in DT, ignored if a coproc has only one IRQ
+ *     handler - irq handler function aware of this particular IRQ functionality
+ */
+struct pcoproc_irq {
+    const char *name;
+    void (*handler)(int, void *, struct cpu_user_regs *);
+};
+
+/*
+ * Coprocessor platform description
+ * A structure what gathers coproc description (irq and mmio so far)
+ */
+struct pcoproc_desc {
+    u32 p_mmio_num;
+    struct pcoproc_mmio *p_mmio;
+    u32 p_irq_num;
+    struct pcoproc_irq *p_irq;
+};
+
+/*
+ * Coprocessor machine IO memory range
+ * This structure is initialized on dt parsing for each io range found for a
+ * coprocessor
+ */
+struct mcoproc_mmio {
+    /* iorange machine base address, taken from a device-tree by name */
+    u64 addr;
+    /* mmio range size from dt */
+    u64 size;
+    /* ioremapped base address, mapped on coproc iniitalization */
+    void __iomem *base;
+    /* pointer to a correspondent platform mmio range description */
+    struct pcoproc_mmio *p_mmio;
+};
+
+/*
+ * Coprocessor machine IRQ
+ * This structure is initialized on dt parsing for each irq found for a
+ * coprocessor.
+ * An interrupt handler receives a triggered irq number and this seems to be
+ * enough to inject an interrupt to a domain.
+ * This description will be used in cases when we need to inject an interrupt
+ * manually (without receiving it from HW).
+ */
+struct mcoproc_irq {
+    /* actual IRQ number */
+    int irq; 
+    /* pointer to a correspondent platform IRQ description */
+    struct pcoproc_irq *p_irq;
+};
+
+/*
+ * Virtual coprocessor's IO memory range
+ * This structure reflects how the coproc's specific mmio is mapped in this
+ * particular domain for this unique vcoproc device
+ */
+struct vcoproc_mmio {
+    /* address to which mmio range is mapped within a specific domain */
+    u64 addr;
+    /* link to a specific regs io range of the coproc */
+    struct mcoproc_mmio *m_mmio;
+     /* unique vcoproc device which corresponds to the domain of this vmmio */
+    struct vcoproc_instance *vcoproc;
+};
+
+/*
+ * Currently IRQ remapping is not supported by XEN so we do not define specific
+ * v_ interrupt description.
+ */
+
+/* machine specific coproc device */
+struct mcoproc_device {
     struct device *dev;
 
     /* the number of memory ranges for this coproc */
     u32 num_mmios;
     /* the array of memory ranges for this coproc */
-    struct mmio *mmios;
+    struct mcoproc_mmio *mmios;
     /* the number of irqs for this coproc */
     u32 num_irqs;
     /* the array of irqs for this coproc */
-    unsigned int *irqs;
+    struct mcoproc_irq *irqs;
 
     /*
      * this list is used to append this coproc
@@ -89,7 +185,6 @@ struct coproc_ops {
 
 /* vcoproc read/write operation context */
 struct vcoproc_rw_context {
-    struct coproc_device *coproc;
     struct hsr_dabt dabt;
     uint32_t offset;
     struct vcoproc_instance *vcoproc;
@@ -111,7 +206,7 @@ enum vcoproc_state {
 
 /* per-domain vcoproc instance */
 struct vcoproc_instance {
-    struct coproc_device *coproc;
+    struct mcoproc_device *mcoproc;
     struct domain *domain;
     spinlock_t lock;
     /* vcoproc state for scheduling */
@@ -131,6 +226,11 @@ struct vcoproc_instance {
 
     /* scheduler-specific data */
     void *sched_priv;
+
+    /* the number of memory ranges for this vcoproc */
+    u32 num_mmios;
+    /* the array of memory ranges for this vcoproc */
+    struct vcoproc_mmio *mmios;
 
     /* vcoproc implementation specific data */
     void *priv;
@@ -171,38 +271,36 @@ enum COPROC_DBG_LEVEL
     coproc_dev_print(dev, XENLOG_INFO,    COPROC_DBG_INFO, fmt, ## __VA_ARGS__)
 #define COPROC_DEBUG(dev, fmt, ...)                                            \
     coproc_dev_print(dev, XENLOG_DEBUG,   COPROC_DBG_DEBUG, fmt, ## __VA_ARGS__)
-#define COPROC_VERBOSE(dev, fmt, ...)                                            \
+#define COPROC_VERBOSE(dev, fmt, ...)                                          \
     coproc_dev_print(dev, XENLOG_DEBUG,   COPROC_DBG_VERB, fmt, ## __VA_ARGS__)
 
 void coproc_init(void);
-struct coproc_device * coproc_alloc(struct dt_device_node *,
-                                    const struct coproc_ops *);
-int coproc_register(struct coproc_device *);
-void coproc_release(struct coproc_device *);
-struct vcoproc_instance *coproc_get_vcoproc(struct domain *,
-                                            struct coproc_device *);
+struct mcoproc_device * coproc_alloc(struct dt_device_node *,
+                                     const struct pcoproc_desc *,
+                                     const struct coproc_ops *);
+int coproc_register(struct mcoproc_device *);
+void coproc_release(struct mcoproc_device *);
 int vcoproc_domain_init(struct domain *);
 void vcoproc_domain_free(struct domain *);
 int coproc_do_domctl(struct xen_domctl *, struct domain *,
                      XEN_GUEST_HANDLE_PARAM(xen_domctl_t));
-bool_t coproc_is_attached_to_domain(struct domain *, const char *);
 void vcoproc_continue_running(struct vcoproc_instance *);
 int coproc_release_vcoprocs(struct domain *);
+int vcoproc_handle_node(struct domain *, void *, const struct dt_device_node *);
 
 #define dev_path(dev) dt_node_full_name(dev_to_dt(dev))
 
-static inline void vcoproc_get_rw_context(struct domain *d, struct mmio *mmio,
-                                          mmio_info_t *info,
-                                          struct vcoproc_rw_context *ctx)
+static inline void
+vcoproc_get_rw_context(struct domain *d, struct vcoproc_mmio *v_mmio,
+                       mmio_info_t *info, struct vcoproc_rw_context *ctx)
 {
-    ctx->coproc = mmio->coproc;
     ctx->dabt = info->dabt;
-    ctx->offset = info->gpa - mmio->addr;
-    ctx->vcoproc = coproc_get_vcoproc(d, ctx->coproc);
-    BUG_ON(ctx->vcoproc == NULL);
+    ctx->offset = info->gpa - v_mmio->addr;
+    ctx->vcoproc = v_mmio->vcoproc;
 }
 
-/* time slice for this vcoproc has finished, save context and pause:
+/*
+ * time slice for this vcoproc has finished, save context and pause:
  * return value:
  *    0 - on success
  *   >0 - if more time is needed: time in ms that vcoproc still needs
@@ -210,13 +308,15 @@ static inline void vcoproc_get_rw_context(struct domain *d, struct mmio *mmio,
  *   <0 - unrecoverable failure: no future context switches are possible,
  *        coproc must be considered as non-functional
  */
-static inline s_time_t vcoproc_context_switch_from(struct vcoproc_instance *vcoproc)
+static inline s_time_t
+vcoproc_context_switch_from(struct vcoproc_instance *vcoproc)
 {
     ASSERT(vcoproc);
-    return vcoproc->coproc->ops->ctx_switch_from(vcoproc);
+    return vcoproc->mcoproc->ops->ctx_switch_from(vcoproc);
 }
 
-/* new vcoproc has time slice, restore context and unpause:
+/*
+ * new vcoproc has time slice, restore context and unpause:
  * return value:
  *    0 - on success
  *   <0 - unrecoverable failure: no future context switches are possible,
@@ -225,7 +325,7 @@ static inline s_time_t vcoproc_context_switch_from(struct vcoproc_instance *vcop
 static inline int vcoproc_context_switch_to(struct vcoproc_instance *vcoproc)
 {
     ASSERT(vcoproc);
-    return vcoproc->coproc->ops->ctx_switch_to(vcoproc);
+    return vcoproc->mcoproc->ops->ctx_switch_to(vcoproc);
 }
 
 #endif /* __ARCH_ARM_COPROC_COPROC_H__ */

--- a/xen/arch/arm/coproc/plat/Makefile
+++ b/xen/arch/arm/coproc/plat/Makefile
@@ -1,1 +1,1 @@
-obj-y += coproc_xxx.o
+subdir-y += coproc_xxx

--- a/xen/arch/arm/coproc/plat/coproc_xxx.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx.c
@@ -34,12 +34,14 @@ static s_time_t coproc_wait_time = MILLISECS(500);
 static int vcoproc_xxx_read(struct vcpu *v, mmio_info_t *info, register_t *r,
                             void *priv)
 {
-    struct mmio *mmio = priv;
+    struct vcoproc_mmio *mmio = priv;
     struct vcoproc_rw_context ctx;
+    struct mcoproc_device *mcoproc;
 
     vcoproc_get_rw_context(v->domain, mmio, info, &ctx);
-    COPROC_DEBUG(ctx.coproc->dev,
-                 "read r%d=%"PRIregister" offset %#08x base %#08x\n",
+    mcoproc = ctx.vcoproc->mcoproc;
+    COPROC_DEBUG(mcoproc->dev, "domain %u, read r%d=%"PRIregister
+                 " offset %#08x base %#08x\n", v->domain->domain_id,
                  ctx.dabt.reg, *r, ctx.offset, (uint32_t)mmio->addr);
 
     return 1;
@@ -48,12 +50,14 @@ static int vcoproc_xxx_read(struct vcpu *v, mmio_info_t *info, register_t *r,
 static int vcoproc_xxx_write(struct vcpu *v, mmio_info_t *info, register_t r,
                              void *priv)
 {
-    struct mmio *mmio = priv;
+    struct vcoproc_mmio *mmio = priv;
     struct vcoproc_rw_context ctx;
+    struct mcoproc_device *mcoproc;
 
     vcoproc_get_rw_context(v->domain, mmio, info, &ctx);
-    COPROC_DEBUG(ctx.coproc->dev,
-                 "write r%d=%"PRIregister" offset %#08x base %#08x\n",
+    mcoproc = ctx.vcoproc->mcoproc;
+    COPROC_DEBUG(mcoproc->dev, "domain %u, write r%d=%"PRIregister
+                 " offset %#08x base %#08x\n", v->domain->domain_id,
                  ctx.dabt.reg, r, ctx.offset, (uint32_t)mmio->addr);
 
 #if 1
@@ -66,22 +70,50 @@ static int vcoproc_xxx_write(struct vcpu *v, mmio_info_t *info, register_t r,
         int i;
 
         /* Just inject all irqs that coproc has */
-        for ( i = 0; i < ctx.coproc->num_irqs; i++ )
-            vgic_vcpu_inject_spi(ctx.vcoproc->domain, ctx.coproc->irqs[i]);
+        for ( i = 0; i < mcoproc->num_irqs; i++ )
+            vgic_vcpu_inject_spi(ctx.vcoproc->domain, mcoproc->irqs[i].irq);
 
         if ( r & CORPOC_XXX_ENABLE )
-            vcoproc_scheduler_vcoproc_wake(ctx.coproc->sched, ctx.vcoproc);
+            vcoproc_scheduler_vcoproc_wake(mcoproc->sched, ctx.vcoproc);
         else
-            vcoproc_scheduler_vcoproc_sleep(ctx.coproc->sched, ctx.vcoproc);
+            vcoproc_scheduler_vcoproc_sleep(mcoproc->sched, ctx.vcoproc);
     }
 #endif
 
     return 1;
 }
 
-static const struct mmio_handler_ops vcoproc_xxx_mmio_handler = {
+static struct mmio_handler_ops vcoproc_xxx_mmio_handler = {
     .read = vcoproc_xxx_read,
     .write = vcoproc_xxx_write,
+};
+
+static struct pcoproc_mmio coproc_xxx_mmio[] = {
+    {
+        .size = 0,
+        .ops = &vcoproc_xxx_mmio_handler,
+    },
+};
+
+static void coproc_xxx_irq_handler(int irq, void *dev,
+                                   struct cpu_user_regs *regs)
+{
+    struct mcoproc_device *coproc_xxx = dev;
+
+    (void)coproc_xxx;
+}
+
+static struct pcoproc_irq coproc_xxx_irq[] = {
+    {
+        .handler = coproc_xxx_irq_handler,
+    },
+};
+
+static const struct pcoproc_desc coproc_xxx_desc = {
+    .p_mmio_num = ARRAY_SIZE(coproc_xxx_mmio),
+    .p_mmio = coproc_xxx_mmio,
+    .p_irq_num = ARRAY_SIZE(coproc_xxx_irq),
+    .p_irq = coproc_xxx_irq,
 };
 
 s_time_t vcoproc_xxx_ctx_switch_from(struct vcoproc_instance *curr)
@@ -98,15 +130,7 @@ static int vcoproc_xxx_ctx_switch_to(struct vcoproc_instance *next)
 
 static int vcoproc_xxx_vcoproc_init(struct vcoproc_instance *vcoproc)
 {
-    int i;
-
-    for ( i = 0; i < vcoproc->coproc->num_mmios; i++ )
-    {
-        struct mmio *mmio = &vcoproc->coproc->mmios[i];
-        register_mmio_handler(vcoproc->domain, &vcoproc_xxx_mmio_handler,
-                              mmio->addr, mmio->size, mmio);
-    }
-
+    /* nothing to do */
     return 0;
 }
 
@@ -122,53 +146,29 @@ static const struct coproc_ops vcoproc_xxx_vcoproc_ops = {
     .ctx_switch_to       = vcoproc_xxx_ctx_switch_to,
 };
 
-static void coproc_xxx_irq_handler(int irq, void *dev,
-                                   struct cpu_user_regs *regs)
-{
-    struct coproc_device *coproc_xxx = dev;
-
-    (void)coproc_xxx;
-}
-
 static int coproc_xxx_dt_probe(struct dt_device_node *np)
 {
-    struct coproc_device *coproc_xxx;
+    struct mcoproc_device *coproc_xxx;
     struct device *dev = &np->dev;
-    int i, ret;
+    int ret;
 
-    coproc_xxx = coproc_alloc(np, &vcoproc_xxx_vcoproc_ops);
+    coproc_xxx = coproc_alloc(np,  &coproc_xxx_desc, &vcoproc_xxx_vcoproc_ops);
     if ( IS_ERR_OR_NULL(coproc_xxx) )
-        return PTR_ERR(coproc_xxx);
-
-    for ( i = 0; i < coproc_xxx->num_irqs; ++i )
     {
-        ret = request_irq(coproc_xxx->irqs[i],
-                         IRQF_SHARED,
-                         coproc_xxx_irq_handler,
-                         "coproc_xxx irq",
-                         coproc_xxx);
-        if ( ret )
-        {
-            COPROC_ERROR(dev, "failed to request irq %d (%u)\n", i,
-                         coproc_xxx->irqs[i]);
-            goto out_release_irqs;
-        }
+        ret = PTR_ERR(coproc_xxx);
+        COPROC_DEBUG(dev, "failed to allocate coproc (%d)\n", ret);
+        return ret;
     }
 
     ret = coproc_register(coproc_xxx);
     if ( ret )
     {
         COPROC_DEBUG(dev, "failed to register coproc (%d)\n", ret);
-        goto out_release_irqs;
+        coproc_release(coproc_xxx);
+        return ret;
     }
 
     return 0;
-
-out_release_irqs:
-    while ( i-- )
-        release_irq(coproc_xxx->irqs[i], coproc_xxx);
-    coproc_release(coproc_xxx);
-    return ret;
 }
 
 static const struct dt_device_match coproc_xxx_dt_match[] __initconst =
@@ -177,17 +177,12 @@ static const struct dt_device_match coproc_xxx_dt_match[] __initconst =
     { /* sentinel */ },
 };
 
-static __init int coproc_xxx_init(struct dt_device_node *dev, const void *data)
+static __init int coproc_xxx_init(struct dt_device_node *np, const void *data)
 {
-    int ret;
+    /*TODO: Decide should we still need used by DOMID_XEN */
+    dt_device_set_used_by(np, DOMID_XEN);
 
-    dt_device_set_used_by(dev, DOMID_XEN);
-
-    ret = coproc_xxx_dt_probe(dev);
-    if ( ret )
-        return ret;
-
-    return 0;
+    return coproc_xxx_dt_probe(np);
 }
 
 DT_DEVICE_START(coproc_xxx, "COPROC_XXX", DEVICE_COPROC)

--- a/xen/arch/arm/coproc/plat/coproc_xxx/Makefile
+++ b/xen/arch/arm/coproc/plat/coproc_xxx/Makefile
@@ -1,0 +1,1 @@
+obj-y += coproc_xxx.o coproc_xxc.o

--- a/xen/arch/arm/coproc/plat/coproc_xxx/coproc_xxc.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx/coproc_xxc.c
@@ -1,0 +1,216 @@
+/*
+ * xen/arch/arm/coproc/plat/coproc_xxc.c
+ *
+ * COPROC_XXC platform specific code
+ * This is an example of description of a complex coprocessor platform code.
+ * This is an example of a coprocessor description which shares common code
+ * with another coprocessor.
+ *
+ * Andrii Anisov <Andrii_Anisov@epam.com>
+ * Copyright (C) 2017 EPAM Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <xen/init.h>
+#include <xen/err.h>
+#include <xen/irq.h>
+
+#include "coproc_xxx.h"
+
+#define DT_MATCH_COPROC_XXC DT_MATCH_COMPATIBLE("vendor_xxx,coproc_xxc")
+
+static int vcoproc_xxc_op_write(struct vcpu *v, mmio_info_t *info, register_t r,
+                                void *priv);
+static int vcoproc_xxc_mmu_write(struct vcpu *v, mmio_info_t *info,
+                                 register_t r, void *priv);
+
+static struct mmio_handler_ops vcoproc_xxc_op_mmio_handler = {
+    .read = vcoproc_xxx_read,
+    .write = vcoproc_xxc_op_write,
+};
+
+static struct mmio_handler_ops vcoproc_xxc_mmu_mmio_handler = {
+    .read = vcoproc_xxx_read,
+    .write = vcoproc_xxc_mmu_write,
+};
+
+static struct mmio_handler_ops vcoproc_xxc_sram_mmio_handler = {
+    .read = vcoproc_xxx_read,
+    .write = vcoproc_xxx_write,
+};
+
+static struct pcoproc_mmio coproc_xxc_mmio[] = {
+    {
+        .name = "op",
+        .size = 0x1000,
+        .ops = &vcoproc_xxc_op_mmio_handler,
+    },
+    {
+        .name = "mmu",
+        .size = 0x1000,
+        .ops = &vcoproc_xxc_mmu_mmio_handler,
+    },
+    {
+        .name = "sram",
+        .size = 0,
+        .ops = &vcoproc_xxc_sram_mmio_handler,
+    },
+};
+
+enum {
+    COPROC_XXC_OP = 0,
+    COPROC_XXC_MMU
+};
+
+static struct pcoproc_irq coproc_xxc_irq[] = {
+    {
+        .name = "op",
+        .handler = coproc_xxx_irq_handler,
+    },
+    {
+        .name = "mmu",
+        .handler = coproc_xxx_irq_handler,
+    },
+};
+
+static const struct pcoproc_desc coproc_xxc_desc = {
+    .p_mmio_num = ARRAY_SIZE(coproc_xxc_mmio),
+    .p_mmio = coproc_xxc_mmio,
+    .p_irq_num = ARRAY_SIZE(coproc_xxc_irq),
+    .p_irq = coproc_xxc_irq,
+};
+
+static int vcoproc_xxc_op_write(struct vcpu *v, mmio_info_t *info, register_t r,
+                                void *priv)
+{
+    struct vcoproc_mmio *mmio = priv;
+    struct vcoproc_rw_context ctx;
+    struct mcoproc_device *mcoproc;
+
+    vcoproc_get_rw_context(v->domain, mmio, info, &ctx);
+    mcoproc = ctx.vcoproc->mcoproc;
+    COPROC_DEBUG(mcoproc->dev, "domain %u, write r%d=%"PRIregister
+                 " offset %#08x base %#08x name %s\n",
+                 v->domain->domain_id, ctx.dabt.reg, r, ctx.offset,
+                 (uint32_t)mmio->addr, mmio->m_mmio->p_mmio->name?:"NONAME");
+
+#if 1
+    /* for debug purposes */
+#define COPROC_XXC_OP_INT_REG   0x20
+    if ( ctx.offset == COPROC_XXC_OP_INT_REG )
+    {
+        int i;
+
+        /* Look for OP irq to inject */
+        for ( i = 0; i < mcoproc->num_irqs; i++ )
+            if ( mcoproc->irqs[i].p_irq == &coproc_xxc_irq[COPROC_XXC_OP] )
+            {
+                vgic_vcpu_inject_spi(ctx.vcoproc->domain, mcoproc->irqs[i].irq);
+                break;
+            }
+    }
+    else
+        vcoproc_xxx_write(v, info, r, priv);
+#endif
+
+    return 1;
+}
+
+static int vcoproc_xxc_mmu_write(struct vcpu *v, mmio_info_t *info,
+                                 register_t r, void *priv)
+{
+    struct vcoproc_mmio *mmio = priv;
+    struct vcoproc_rw_context ctx;
+    struct mcoproc_device *mcoproc;
+
+    vcoproc_get_rw_context(v->domain, mmio, info, &ctx);
+    mcoproc = ctx.vcoproc->mcoproc;
+    COPROC_DEBUG(mcoproc->dev, "domain %u, write r%d=%"PRIregister
+                 " offset %#08x base %#08x name %s\n",
+                 v->domain->domain_id, ctx.dabt.reg, r, ctx.offset,
+                 (uint32_t)mmio->addr, mmio->m_mmio->p_mmio->name?:"NONAME");
+
+#if 1
+    /* for debug purposes */
+#define COPROC_XXC_MMU_INT_REG   0x30
+    if ( ctx.offset == COPROC_XXC_MMU_INT_REG )
+    {
+        int i;
+
+        /* Look for MMU irq to inject */
+        for ( i = 0; i < mcoproc->num_irqs; i++ )
+            if ( mcoproc->irqs[i].p_irq == &coproc_xxc_irq[COPROC_XXC_MMU] )
+            {
+                vgic_vcpu_inject_spi(ctx.vcoproc->domain, mcoproc->irqs[i].irq);
+                break;
+            }
+    }
+#endif
+
+    return 1;
+}
+
+extern const struct coproc_ops vcoproc_xxx_vcoproc_ops;
+
+static int coproc_xxc_dt_probe(struct dt_device_node *np)
+{
+    struct mcoproc_device *coproc_xxc;
+    struct device *dev = &np->dev;
+    int ret;
+
+    coproc_xxc = coproc_alloc(np,  &coproc_xxc_desc, &vcoproc_xxx_vcoproc_ops);
+    if ( IS_ERR_OR_NULL(coproc_xxc) )
+    {
+        ret = PTR_ERR(coproc_xxc);
+        COPROC_DEBUG(dev, "failed to allocate coproc xxc (%d)\n", ret);
+        return ret;
+    }
+
+    ret = coproc_register(coproc_xxc);
+    if ( ret )
+    {
+        COPROC_DEBUG(dev, "failed to register coproc xxc (%d)\n", ret);
+        coproc_release(coproc_xxc);
+        return ret;
+    }
+
+    return 0;
+}
+
+static const struct dt_device_match coproc_xxc_dt_match[] __initconst =
+{
+    DT_MATCH_COPROC_XXC,
+    { /* sentinel */ },
+};
+
+static __init int coproc_xxc_init(struct dt_device_node *np, const void *data)
+{
+    /*TODO: Decide should we still need used by DOMID_XEN */
+    dt_device_set_used_by(np, DOMID_XEN);
+
+    return coproc_xxc_dt_probe(np);
+}
+
+DT_DEVICE_START(coproc_xxc, "COPROC_XXC", DEVICE_COPROC)
+    .dt_match = coproc_xxc_dt_match,
+    .init = coproc_xxc_init,
+DT_DEVICE_END
+
+/*
+ * Local variables:
+ * mode: C
+ * c-file-style: "BSD"
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */
+

--- a/xen/arch/arm/coproc/plat/coproc_xxx/coproc_xxx.c
+++ b/xen/arch/arm/coproc/plat/coproc_xxx/coproc_xxx.c
@@ -24,14 +24,12 @@
 
 #include "coproc_xxx.h"
 
-/* TODO Some common code from here might be moved to framework */
-
 /* the amount of time to wait for the particular coproc */
 static s_time_t coproc_wait_time = MILLISECS(500);
 
 #define DT_MATCH_COPROC_XXX DT_MATCH_COMPATIBLE("vendor_xxx,coproc_xxx")
 
-static int vcoproc_xxx_read(struct vcpu *v, mmio_info_t *info, register_t *r,
+int vcoproc_xxx_read(struct vcpu *v, mmio_info_t *info, register_t *r,
                             void *priv)
 {
     struct vcoproc_mmio *mmio = priv;
@@ -47,7 +45,7 @@ static int vcoproc_xxx_read(struct vcpu *v, mmio_info_t *info, register_t *r,
     return 1;
 }
 
-static int vcoproc_xxx_write(struct vcpu *v, mmio_info_t *info, register_t r,
+int vcoproc_xxx_write(struct vcpu *v, mmio_info_t *info, register_t r,
                              void *priv)
 {
     struct vcoproc_mmio *mmio = priv;
@@ -95,7 +93,7 @@ static struct pcoproc_mmio coproc_xxx_mmio[] = {
     },
 };
 
-static void coproc_xxx_irq_handler(int irq, void *dev,
+void coproc_xxx_irq_handler(int irq, void *dev,
                                    struct cpu_user_regs *regs)
 {
     struct mcoproc_device *coproc_xxx = dev;
@@ -139,7 +137,7 @@ static void vcoproc_xxx_vcoproc_deinit(struct vcoproc_instance *vcoproc_xxx)
     /* nothing to do */
 }
 
-static const struct coproc_ops vcoproc_xxx_vcoproc_ops = {
+struct coproc_ops vcoproc_xxx_vcoproc_ops = {
     .vcoproc_init        = vcoproc_xxx_vcoproc_init,
     .vcoproc_deinit      = vcoproc_xxx_vcoproc_deinit,
     .ctx_switch_from     = vcoproc_xxx_ctx_switch_from,

--- a/xen/arch/arm/coproc/plat/coproc_xxx/coproc_xxx.h
+++ b/xen/arch/arm/coproc/plat/coproc_xxx/coproc_xxx.h
@@ -20,8 +20,14 @@
 #ifndef __ARCH_ARM_COPROC_PLAT_COPROC_XXX_H__
 #define __ARCH_ARM_COPROC_PLAT_COPROC_XXX_H__
 
-#include "../coproc.h"
-#include "common.h"
+#include "../../coproc.h"
+#include "../common.h"
+
+int vcoproc_xxx_read(struct vcpu *, mmio_info_t *, register_t *, void *);
+
+int vcoproc_xxx_write(struct vcpu *, mmio_info_t *, register_t, void *);
+
+void coproc_xxx_irq_handler(int, void *, struct cpu_user_regs *);
 
 #endif /* __ARCH_ARM_COPROC_PLAT_COPROC_XXX_H__ */
 

--- a/xen/arch/arm/coproc/schedule.h
+++ b/xen/arch/arm/coproc/schedule.h
@@ -88,9 +88,9 @@ struct vcoproc_scheduler {
     void *sched_priv;
 };
 
-struct coproc_device;
+struct mcoproc_device;
 
-struct vcoproc_scheduler *vcoproc_scheduler_init(struct coproc_device *);
+struct vcoproc_scheduler *vcoproc_scheduler_init(struct mcoproc_device *);
 int vcoproc_scheduler_vcoproc_init(struct vcoproc_scheduler *,
                                    struct vcoproc_instance *);
 int vcoproc_scheduler_vcoproc_destroy(struct vcoproc_scheduler *,

--- a/xen/common/device_tree.c
+++ b/xen/common/device_tree.c
@@ -1517,6 +1517,11 @@ bool_t dt_device_for_passthrough(const struct dt_device_node *device)
 
 }
 
+bool_t dt_device_for_scf(const struct dt_device_node *device)
+{
+    return (dt_find_property(device, "xen,coproc", NULL) != NULL);
+}
+
 static int __dt_parse_phandle_with_args(const struct dt_device_node *np,
                                         const char *list_name,
                                         const char *cells_name,

--- a/xen/common/device_tree.c
+++ b/xen/common/device_tree.c
@@ -1710,7 +1710,7 @@ int dt_parse_phandle_with_args(const struct dt_device_node *np,
  * @allnextpp: pointer to ->allnext from last allocated device_node
  * @fpsize: Size of the node path up at the current depth.
  */
-static unsigned long __init unflatten_dt_node(const void *fdt,
+static unsigned long unflatten_dt_node(const void *fdt,
                                               unsigned long mem,
                                               unsigned long *p,
                                               struct dt_device_node *dad,
@@ -1955,11 +1955,12 @@ static unsigned long __init unflatten_dt_node(const void *fdt,
  * @fdt: The fdt to expand
  * @mynodes: The device_node tree created by the call
  */
-static void __init __unflatten_device_tree(const void *fdt,
+static void *__unflatten_device_tree(const void *fdt,
                                            struct dt_device_node **mynodes)
 {
     unsigned long start, mem, size;
     struct dt_device_node **allnextp = mynodes;
+    void *ptr;
 
     dt_dprintk(" -> unflatten_device_tree()\n");
 
@@ -1976,7 +1977,11 @@ static void __init __unflatten_device_tree(const void *fdt,
     dt_dprintk("  size is %#lx allocating...\n", size);
 
     /* Allocate memory for the expanded device tree */
-    mem = (unsigned long)_xmalloc (size + 4, __alignof__(struct dt_device_node));
+    ptr = _xmalloc (size + 4, __alignof__(struct dt_device_node));
+    if ( ptr == NULL )
+        goto out;
+
+    mem = (unsigned long)ptr;
 
     ((__be32 *)mem)[size / 4] = cpu_to_be32(0xdeadbeef);
 
@@ -1994,6 +1999,9 @@ static void __init __unflatten_device_tree(const void *fdt,
     *allnextp = NULL;
 
     dt_dprintk(" <- unflatten_device_tree()\n");
+
+out:
+    return ptr;
 }
 
 static void dt_alias_add(struct dt_alias_prop *ap,
@@ -2080,6 +2088,11 @@ void __init dt_unflatten_host_device_tree(void)
 {
     __unflatten_device_tree(device_tree_flattened, &dt_host);
     dt_alias_scan();
+}
+
+void *dt_unflatten_device_tree(void *fdt, struct dt_device_node ** pdt)
+{
+    return __unflatten_device_tree(fdt, pdt);
 }
 
 /*

--- a/xen/common/device_tree.c
+++ b/xen/common/device_tree.c
@@ -1522,6 +1522,11 @@ bool_t dt_device_for_scf(const struct dt_device_node *device)
     return (dt_find_property(device, "xen,coproc", NULL) != NULL);
 }
 
+bool_t dt_device_is_vcoproc(const struct dt_device_node *device)
+{
+    return (dt_find_property(device, "xen,vcoproc", NULL) != NULL);
+}
+
 static int __dt_parse_phandle_with_args(const struct dt_device_node *np,
                                         const char *list_name,
                                         const char *cells_name,

--- a/xen/common/device_tree.c
+++ b/xen/common/device_tree.c
@@ -209,6 +209,33 @@ int dt_property_read_string(const struct dt_device_node *np,
     return 0;
 }
 
+int dt_property_match_string(const struct dt_device_node *np,
+                             const char *propname, const char *string)
+{
+    const struct dt_property *prop = dt_find_property(np, propname, NULL);
+    size_t l;
+    int i;
+    const char *p, *end;
+
+    if (!prop)
+        return -EINVAL;
+    if (!prop->value)
+        return -ENODATA;
+
+    p = prop->value;
+    end = p + prop->length;
+
+    for (i = 0; p < end; i++, p += l) {
+        l = strnlen(p, end - p) + 1;
+        if (p + l > end)
+            return -EILSEQ;
+        dt_dprintk("comparing %s with %s\n", string, p);
+        if (strcmp(string, p) == 0)
+            return i; /* Found it; return index */
+    }
+    return -ENODATA;
+}
+
 bool_t dt_device_is_compatible(const struct dt_device_node *device,
                                const char *compat)
 {

--- a/xen/include/public/domctl.h
+++ b/xen/include/public/domctl.h
@@ -1147,7 +1147,7 @@ DEFINE_XEN_GUEST_HANDLE(xen_domctl_psr_cat_op_t);
 /* Attach a coproc to a guest. */
 struct xen_domctl_attach_coproc {
     uint32_t size; /* length of the path */
-    XEN_GUEST_HANDLE_64(char) path; /* path to the device tree node */
+    XEN_GUEST_HANDLE_64(void) fdt; /* fdt blob */
 };
 typedef struct xen_domctl_attach_coproc xen_domctl_attach_coproc_t;
 DEFINE_XEN_GUEST_HANDLE(xen_domctl_attach_coproc_t);
@@ -1229,7 +1229,7 @@ struct xen_domctl {
 #define XEN_DOMCTL_monitor_op                    77
 #define XEN_DOMCTL_psr_cat_op                    78
 #define XEN_DOMCTL_soft_reset                    79
-#define XEN_DOMCTL_attach_coproc                 80
+#define XEN_DOMCTL_browse_pfdt                   80
 #define XEN_DOMCTL_gdbsx_guestmemio            1000
 #define XEN_DOMCTL_gdbsx_pausevcpu             1001
 #define XEN_DOMCTL_gdbsx_unpausevcpu           1002

--- a/xen/include/xen/device_tree.h
+++ b/xen/include/xen/device_tree.h
@@ -639,6 +639,17 @@ bool_t dt_device_is_available(const struct dt_device_node *device);
 bool_t dt_device_for_passthrough(const struct dt_device_node *device);
 
 /**
+ * dt_device_for_scf - Check if a device is a coprocessor to be shared
+ * by SCF
+ *
+ * @device: Node to check
+ *
+ * Return true if the property "xen,coproc" is present in the node,
+ * false otherwise.
+ */
+ bool_t dt_device_for_scf(const struct dt_device_node *device);
+
+/**
  * dt_match_node - Tell if a device_node has a matching of dt_device_match
  * @matches: array of dt_device_match structures to search in
  * @node: the dt_device_node structure to match against

--- a/xen/include/xen/device_tree.h
+++ b/xen/include/xen/device_tree.h
@@ -650,6 +650,17 @@ bool_t dt_device_for_passthrough(const struct dt_device_node *device);
  bool_t dt_device_for_scf(const struct dt_device_node *device);
 
 /**
+ * dt_device_is_vcoproc - Check if a device is a virtual coprocessor
+ * to be to be baked by SCF
+ *
+ * @device: Node to check
+ *
+ * Return true if the property "xen,vcoproc" is present in the node,
+ * false otherwise.
+ */
+ bool_t dt_device_is_vcoproc(const struct dt_device_node *device);
+
+/**
  * dt_match_node - Tell if a device_node has a matching of dt_device_match
  * @matches: array of dt_device_match structures to search in
  * @node: the dt_device_node structure to match against

--- a/xen/include/xen/device_tree.h
+++ b/xen/include/xen/device_tree.h
@@ -420,6 +420,18 @@ int dt_property_read_string(const struct dt_device_node *np,
                             const char *propname, const char **out_string);
 
 /**
+ * dt_property_match_string() - Find string in a list and return index
+ * @np: pointer to node containing string list property
+ * @propname: string list property name
+ * @string: pointer to string to search for in string list
+ *
+ * This function searches a string list property and returns the index
+ * of a specific string value.
+ */
+int dt_property_match_string(const struct dt_device_node *np,
+                             const char *propname, const char *string);
+
+/**
  * Checks if the given "compat" string matches one of the strings in
  * the device's "compatible" property
  */

--- a/xen/include/xen/device_tree.h
+++ b/xen/include/xen/device_tree.h
@@ -197,6 +197,17 @@ int device_tree_for_each_node(const void *fdt,
 void __init dt_unflatten_host_device_tree(void);
 
 /**
+ * dt_unflatten_device_tree - Unflatten a device tree
+ *
+ * Create a hierarchical device tree for a DTB to be able
+ * to retrieve parents.
+ *
+ * Returns a pointer to memory allocated for unflattened device tree.
+ * Return value must be used for memory freeing solely.
+ */
+void *dt_unflatten_device_tree(void *fdt, struct dt_device_node ** pdt);
+
+/**
  * IRQ translation callback
  * TODO: For the moment we assume that we only have ONE
  * interrupt-controller.

--- a/xen/xsm/flask/hooks.c
+++ b/xen/xsm/flask/hooks.c
@@ -748,7 +748,7 @@ static int flask_domctl(struct domain *d, int cmd)
     case XEN_DOMCTL_soft_reset:
         return current_has_perm(d, SECCLASS_DOMAIN2, DOMAIN2__SOFT_RESET);
 
-    case XEN_DOMCTL_attach_coproc:
+    case XEN_DOMCTL_browse_pfdt:
         return current_has_perm(d, SECCLASS_DOMAIN2, DOMAIN2__ATTACH_COPROC);
 
     default:


### PR DESCRIPTION
This rework covers following bits:

- basically introduces platform, machine, virtual coprocessor abstractions
- basically introduces a platform coprocessor description model
- introduces SCF configuration using device tree nodes only

Also closes following issues:
- #16 
- #20 
- #35 
- #50 

Also discards #52 , because latest version of the documentation is included in this pull request.