### PR TITLE
arm/coproc: Allow iomem access to iomem if not used by Dom0

### DIFF
--- a/xen/arch/arm/domain_build.c
+++ b/xen/arch/arm/domain_build.c
@@ -1156,16 +1156,16 @@ static int handle_coproc_node(struct domain *d, struct dt_device_node *dev,
         }
     }
 
-    if ( !need_mapping )
-        return 0;
-
-    /* Map MMIO ranges (which coproc doesn't want to trap) to domain */
+    /*
+     * Map or permit access to MMIO ranges (which coproc doesn't want to trap)
+     * to domain: if coproc is not used in this domain then permit access,
+     * otherwise map
+     */
     num_mmios = dt_number_of_address(dev);
     for ( i = 0; i < num_mmios; i++ )
     {
         struct map_range_data mr_data = { .d = d, .p2mt = p2mt };
         u64 addr, size;
-        u64 map_addr, map_size;
 
         res = dt_device_get_address(dev, i, &addr, &size);
         if ( res )
@@ -1175,23 +1175,43 @@ static int handle_coproc_node(struct domain *d, struct dt_device_node *dev,
             return res;
         }
 
-        while ( coproc_need_map_range_to_domain(d, path, addr, size,
-                                             &map_addr, &map_size) )
+        if ( need_mapping )
         {
-            /* check if the result is ok and map the chunk */
-            if ( (map_addr + map_size > addr + size) || (map_addr < addr) )
+            u64 map_addr, map_size;
+
+            while ( coproc_need_map_range_to_domain(d, path, addr, size,
+                                                    &map_addr, &map_size) )
             {
-                printk(XENLOG_ERR "Invalid mmio range mapping requested by coproc at %lx of size %lu for %s\n",
-                       map_addr, map_size, dt_node_full_name(dev));
+                /* check if the result is ok and map the chunk */
+                if ( (map_addr + map_size > addr + size) || (map_addr < addr) )
+                {
+                    printk(XENLOG_ERR "Invalid mmio range mapping requested by coproc at %lx of size %lu for %s\n",
+                           map_addr, map_size, dt_node_full_name(dev));
+                    return res;
+                }
+
+                res = map_range_to_domain(dev, map_addr, map_size, &mr_data);
+                if ( res )
+                    return res;
+
+                /* advance counters to the new chunk */
+                addr = map_addr;
+                size -= map_size;
+            }
+        }
+        else
+        {
+            res = iomem_permit_access(d, paddr_to_pfn(addr),
+                                      paddr_to_pfn(PAGE_ALIGN(addr + size - 1)));
+            if ( res )
+            {
+                printk(XENLOG_ERR "Unable to permit to dom%d access to"
+                       " 0x%"PRIx64" - 0x%"PRIx64" for coproc %s\n",
+                       d->domain_id,
+                       addr & PAGE_MASK, PAGE_ALIGN(addr + size) - 1,
+                       dt_node_full_name(dev));
                 return res;
             }
-            res = map_range_to_domain(dev, map_addr, map_size, &mr_data);
-            if ( res )
-                return res;
-
-            /* advance counters to the new chunk */
-            addr = map_addr;
-            size -= map_size;
         }
     }
     return 0;


### PR DESCRIPTION
Allow accessing IOMEM range(s) of a coproc device if it
is not used by Dom0: currently if Dom0 doesn't use coproc
then IOMEM range(s) of the device are not allowed to be accessed
by other domains which do.
Fix this by permitting access to IOMEM.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>