### PR TITLE
tools/hotplug: create XEN_LOG_DIR at runtime

### DIFF
--- a/tools/hotplug/Linux/init.d/xencommons.in
+++ b/tools/hotplug/Linux/init.d/xencommons.in
@@ -58,6 +58,7 @@ do_start () {
 
 	mkdir -p ${XEN_RUN_DIR}
 	mkdir -p ${XEN_LOCK_DIR}
+	mkdir -p ${XEN_LOG_DIR}
 
 	@XEN_SCRIPT_DIR@/launch-xenstore || exit 1
 


### PR DESCRIPTION
/var/log could be a tmpfs mount point, so create xen subfolder at runtime.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>