### PR TITLE
libxl: determine driver domain by libxl local entry

### DIFF
--- a/tools/libxl/libxl_disk.c
+++ b/tools/libxl/libxl_disk.c
@@ -1185,12 +1185,12 @@ static void libxl_device_disk_merge(libxl_ctx *ctx, void *d1, void *d2)
     }
 }
 
-static int libxl_device_disk_dm_needed(void *e, unsigned domid)
+static int libxl_device_disk_dm_needed(libxl__gc *gc, void *e, unsigned domid)
 {
     libxl_device_disk *elem = e;
 
     return elem->backend == LIBXL_DISK_BACKEND_QDISK &&
-           elem->backend_domid == domid;
+           (!libxl__is_driver_domain(gc, elem->backend_domid));
 }
 
 LIBXL_DEFINE_DEVICE_LIST(disk)

--- a/tools/libxl/libxl_dm.c
+++ b/tools/libxl/libxl_dm.c
@@ -2527,7 +2527,7 @@ int libxl__need_xenpv_qemu(libxl__gc *gc, libxl_domain_config *d_config)
             continue;
 
         for (i = 0; i < num; i++) {
-            if (dt->dm_needed(libxl__device_type_get_elem(dt, d_config, i),
+            if (dt->dm_needed(gc, libxl__device_type_get_elem(dt, d_config, i),
                               domid)) {
                 ret = 1;
                 goto out;
@@ -2536,7 +2536,7 @@ int libxl__need_xenpv_qemu(libxl__gc *gc, libxl_domain_config *d_config)
     }
 
     for (i = 0; i < d_config->num_channels; i++) {
-        if (d_config->channels[i].backend_domid == domid) {
+        if (!libxl__is_driver_domain(gc, d_config->channels[i].backend_domid)) {
             /* xenconsoled is limited to the first console only.
                Until this restriction is removed we must use qemu for
                secondary consoles which includes all channels. */

--- a/tools/libxl/libxl_internal.c
+++ b/tools/libxl/libxl_internal.c
@@ -575,6 +575,24 @@ void libxl__update_domain_configuration(libxl__gc *gc,
     dst->b_info.video_memkb = src->b_info.video_memkb;
 }
 
+int libxl__is_driver_domain(libxl__gc *gc, uint32_t domid)
+{
+    const char *val;
+    int rc;
+
+    char *dom_path = libxl__xs_get_dompath(gc, domid);
+
+    if (!dom_path) {
+        return 0;
+    }
+
+    rc = libxl__xs_read_checked(gc, XBT_NULL,
+                                GCSPRINTF("%s/libxl", dom_path), &val);
+    if (rc) return 0;
+
+    return val != NULL;
+}
+
 /*
  * Local variables:
  * mode: C

--- a/tools/libxl/libxl_internal.h
+++ b/tools/libxl/libxl_internal.h
@@ -3545,7 +3545,7 @@ typedef void (*device_copy_fn_t)(libxl_ctx *, void *, void *);
 typedef void (*device_dispose_fn_t)(void *);
 typedef int (*device_compare_fn_t)(void *, void *);
 typedef void (*device_merge_fn_t)(libxl_ctx *, void *, void *);
-typedef int (*device_dm_needed_fn_t)(void *, unsigned);
+typedef int (*device_dm_needed_fn_t)(libxl__gc *, void *, unsigned);
 typedef void (*device_update_config_fn_t)(libxl__gc *, void *, void *);
 typedef int (*device_update_devid_fn_t)(libxl__gc *, uint32_t, void *);
 typedef int (*device_from_xenstore_fn_t)(libxl__gc *, const char *,
@@ -4414,6 +4414,10 @@ void* libxl__device_list(libxl__gc *gc, const struct libxl_device_type *dt,
                          uint32_t domid, int *num);
 void libxl__device_list_free(const struct libxl_device_type *dt,
                              void *list, int num);
+
+/* Check if domain is driver domain */
+_hidden int libxl__is_driver_domain(libxl__gc *gc, uint32_t domid);
+
 #endif
 
 /*

--- a/tools/libxl/libxl_usb.c
+++ b/tools/libxl/libxl_usb.c
@@ -1944,12 +1944,13 @@ static int libxl_device_usbctrl_compare(libxl_device_usbctrl *d1,
     return COMPARE_USBCTRL(d1, d2);
 }
 
-static int libxl_device_usbctrl_dm_needed(void *e, unsigned domid)
+static int libxl_device_usbctrl_dm_needed(libxl__gc * gc, void *e,
+                                          unsigned domid)
 {
     libxl_device_usbctrl *elem = e;
 
     return elem->type == LIBXL_USBCTRL_TYPE_QUSB &&
-           elem->backend_domid == domid;
+           (!libxl__is_driver_domain(gc, elem->backend_domid));
 }
 
 static int libxl_device_usbdev_compare(libxl_device_usbdev *d1,


### PR DESCRIPTION
Currently driver domain is determined by comparison with libxl
client domain (dom 0). As result libxl treats domain with
beckends as driver domain and handles it differently on destroying:
waits that driver domain removes frontend xen store entries.
The fix is to use presence of local libxl entry to determine
the driver domain.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>