### PR TITLE
Revert "libxl: determine driver domain by libxl local entry"

### DIFF
--- a/tools/libxl/libxl_device.c
+++ b/tools/libxl/libxl_device.c
@@ -265,7 +265,7 @@ static int disk_try_backend(disk_try_backend_args *a,
         if (libxl_defbool_val(a->disk->colo_enable))
             goto bad_colo;
 
-        if (libxl__is_driver_domain(gc, a->disk->backend_domid)) {
+        if (a->disk->backend_domid != LIBXL_TOOLSTACK_DOMID) {
             LOG(DEBUG, "Disk vdev=%s, is using a storage driver domain, "
                        "skipping physical device check", a->disk->vdev);
             return backend;
@@ -374,7 +374,7 @@ int libxl__device_disk_set_backend(libxl__gc *gc, libxl_device_disk *disk) {
         memset(&a.stab, 0, sizeof(a.stab));
     } else if ((disk->backend == LIBXL_DISK_BACKEND_UNKNOWN ||
                 disk->backend == LIBXL_DISK_BACKEND_PHY) &&
-               (!libxl__is_driver_domain(gc, disk->backend_domid)) &&
+               disk->backend_domid == LIBXL_TOOLSTACK_DOMID &&
                !disk->script) {
         if (stat(disk->pdev_path, &a.stab)) {
             LOGE(ERROR, "Disk vdev=%s failed to stat: %s",
@@ -732,7 +732,7 @@ int libxl__device_destroy(libxl__gc *gc, libxl__device *dev)
                 libxl__xs_path_cleanup(gc, t, fe_path);
             libxl__xs_path_cleanup(gc, t, libxl_path);
         }
-        if (!libxl__is_driver_domain(gc, dev->backend_domid) && !libxl_only) {
+        if (dev->backend_domid == domid && !libxl_only) {
             /*
              * The driver domain is in charge of removing what it can
              * from the backend path.
@@ -1110,7 +1110,7 @@ static void device_hotplug(libxl__egc *egc, libxl__ao_device *aodev)
         LOGD(ERROR, aodev->dev->domid, "Failed to get domid");
         goto out;
     }
-    if (libxl__is_driver_domain(gc, aodev->dev->backend_domid)) {
+    if (aodev->dev->backend_domid != domid) {
         LOGD(DEBUG, aodev->dev->domid,
              "Backend domid %d, domid %d, assuming driver domains",
              aodev->dev->backend_domid, domid);

--- a/tools/libxl/libxl_disk.c
+++ b/tools/libxl/libxl_disk.c
@@ -1185,12 +1185,12 @@ static void libxl_device_disk_merge(libxl_ctx *ctx, void *d1, void *d2)
     }
 }
 
-static int libxl_device_disk_dm_needed(libxl__gc *gc, void *e, unsigned domid)
+static int libxl_device_disk_dm_needed(void *e, unsigned domid)
 {
     libxl_device_disk *elem = e;
 
     return elem->backend == LIBXL_DISK_BACKEND_QDISK &&
-           (!libxl__is_driver_domain(gc, elem->backend_domid));
+           elem->backend_domid == domid;
 }
 
 LIBXL_DEFINE_DEVICE_LIST(disk)

--- a/tools/libxl/libxl_dm.c
+++ b/tools/libxl/libxl_dm.c
@@ -2527,7 +2527,7 @@ int libxl__need_xenpv_qemu(libxl__gc *gc, libxl_domain_config *d_config)
             continue;
 
         for (i = 0; i < num; i++) {
-            if (dt->dm_needed(gc, libxl__device_type_get_elem(dt, d_config, i),
+            if (dt->dm_needed(libxl__device_type_get_elem(dt, d_config, i),
                               domid)) {
                 ret = 1;
                 goto out;
@@ -2536,7 +2536,7 @@ int libxl__need_xenpv_qemu(libxl__gc *gc, libxl_domain_config *d_config)
     }
 
     for (i = 0; i < d_config->num_channels; i++) {
-        if (!libxl__is_driver_domain(gc, d_config->channels[i].backend_domid)) {
+        if (d_config->channels[i].backend_domid == domid) {
             /* xenconsoled is limited to the first console only.
                Until this restriction is removed we must use qemu for
                secondary consoles which includes all channels. */

--- a/tools/libxl/libxl_internal.c
+++ b/tools/libxl/libxl_internal.c
@@ -575,24 +575,6 @@ void libxl__update_domain_configuration(libxl__gc *gc,
     dst->b_info.video_memkb = src->b_info.video_memkb;
 }
 
-int libxl__is_driver_domain(libxl__gc *gc, uint32_t domid)
-{
-    const char *val;
-    int rc;
-
-    char *dom_path = libxl__xs_get_dompath(gc, domid);
-
-    if (!dom_path) {
-        return 0;
-    }
-
-    rc = libxl__xs_read_checked(gc, XBT_NULL,
-                                GCSPRINTF("%s/libxl", dom_path), &val);
-    if (rc) return 0;
-
-    return val != NULL;
-}
-
 /*
  * Local variables:
  * mode: C

--- a/tools/libxl/libxl_internal.h
+++ b/tools/libxl/libxl_internal.h
@@ -3545,7 +3545,7 @@ typedef void (*device_copy_fn_t)(libxl_ctx *, void *, void *);
 typedef void (*device_dispose_fn_t)(void *);
 typedef int (*device_compare_fn_t)(void *, void *);
 typedef void (*device_merge_fn_t)(libxl_ctx *, void *, void *);
-typedef int (*device_dm_needed_fn_t)(libxl__gc *, void *, unsigned);
+typedef int (*device_dm_needed_fn_t)(void *, unsigned);
 typedef void (*device_update_config_fn_t)(libxl__gc *, void *, void *);
 typedef int (*device_update_devid_fn_t)(libxl__gc *, uint32_t, void *);
 typedef int (*device_from_xenstore_fn_t)(libxl__gc *, const char *,
@@ -4414,10 +4414,6 @@ void* libxl__device_list(libxl__gc *gc, const struct libxl_device_type *dt,
                          uint32_t domid, int *num);
 void libxl__device_list_free(const struct libxl_device_type *dt,
                              void *list, int num);
-
-/* Check if domain is driver domain */
-_hidden int libxl__is_driver_domain(libxl__gc *gc, uint32_t domid);
-
 #endif
 
 /*

--- a/tools/libxl/libxl_usb.c
+++ b/tools/libxl/libxl_usb.c
@@ -1944,13 +1944,12 @@ static int libxl_device_usbctrl_compare(libxl_device_usbctrl *d1,
     return COMPARE_USBCTRL(d1, d2);
 }
 
-static int libxl_device_usbctrl_dm_needed(libxl__gc * gc, void *e,
-                                          unsigned domid)
+static int libxl_device_usbctrl_dm_needed(void *e, unsigned domid)
 {
     libxl_device_usbctrl *elem = e;
 
     return elem->type == LIBXL_USBCTRL_TYPE_QUSB &&
-           (!libxl__is_driver_domain(gc, elem->backend_domid));
+           elem->backend_domid == domid;
 }
 
 static int libxl_device_usbdev_compare(libxl_device_usbdev *d1,


### PR DESCRIPTION
This reverts commit bc916da1b2e31cd31f2d96f40b7100cfe7656f68.

This prevents Xen from creating DomA:
libxl: error: ...Disk vdev=xvda1 failed to stat: /dev/loop0: No such file or directory