### PR TITLE
Add thermal support

### DIFF
--- a/xen/arch/arm/cpufreq/Makefile
+++ b/xen/arch/arm/cpufreq/Makefile
@@ -5,3 +5,4 @@ obj-y += mailbox.o
 obj-y += arm-smc-mailbox.o
 obj-y += iic_dvfs.o
 obj-y += cpufreq_emu.o
+obj-y += rcar_gen3_thermal.o

--- a/xen/arch/arm/cpufreq/cpufreq_emu.c
+++ b/xen/arch/arm/cpufreq/cpufreq_emu.c
@@ -32,6 +32,8 @@
 #include "rcar_def.h"
 #include "iic_dvfs.h"
 
+extern bool cpufreq_debug;
+
 #define EFUSE_AVS0			(0U)
 #define EFUSE_AVS_NUM		(7U)
 static uint32_t efuse_avs = EFUSE_AVS0;
@@ -560,8 +562,8 @@ int dev_pm_opp_set_rate(unsigned long target_freq)
 	}
 
 	/* Change frequency */
-	printk("%s(): switching OPP: %lu Hz --> %lu Hz\n",
-			__func__, old_freq, freq);
+	if (cpufreq_debug)
+		printk("Switching CPU OPP: %lu Hz --> %lu Hz\n", old_freq, freq);
 
 	prate = pll0_clk_round_rate(prate);
 	if (old_prate != prate)

--- a/xen/arch/arm/cpufreq/cpufreq_if.c
+++ b/xen/arch/arm/cpufreq/cpufreq_if.c
@@ -25,6 +25,7 @@
 #include <xen/cpufreq.h>
 #include <xen/pmstat.h>
 #include <xen/guest_access.h>
+#include <xen/keyhandler.h>
 
 #include "scpi_protocol.h"
 
@@ -486,6 +487,14 @@ static void scpi_cpufreq_deinit(void)
 
 }
 
+bool cpufreq_debug = false;
+
+void cpufreq_debug_toggle(unsigned char key)
+{
+    cpufreq_debug = !cpufreq_debug;
+    printk("CPUFreq debug is %s\n", cpufreq_debug ? "enabled" : "disabled");
+}
+
 static int __init cpufreq_driver_init(void)
 {
     int ret;
@@ -530,6 +539,9 @@ out:
         scpi_cpufreq_deinit();
         return ret;
     }
+
+    register_keyhandler('C', cpufreq_debug_toggle,
+                        "enable debug for CPUFreq", 0);
 
     printk("initialized SCPI based CPUFreq\n");
 

--- a/xen/arch/arm/cpufreq/cpufreq_if.c
+++ b/xen/arch/arm/cpufreq/cpufreq_if.c
@@ -401,6 +401,21 @@ static int __init scpi_cpufreq_postinit(void)
     return ret;
 }
 
+static int thermal_init(void)
+{
+	struct dt_device_node *ths;
+	unsigned int num_ths = 0;
+	int rc;
+
+	dt_for_each_device_node(dt_host, ths) {
+		rc = device_init(ths, DEVICE_THS, NULL);
+		if (!rc)
+			num_ths ++;
+	}
+
+	return (num_ths > 0) ? 0 : -ENODEV;
+}
+
 static int __init scpi_cpufreq_preinit(void)
 {
     struct dt_device_node *scpi, *clk, *dvfs_clk;
@@ -420,6 +435,13 @@ static int __init scpi_cpufreq_preinit(void)
 
     scpi = get_scpi_dev()->of_node;
     scpi_ops = get_scpi_ops();
+
+    ret = thermal_init();
+    if ( ret )
+    {
+        printk("failed to initialize thermal (%d)\n", ret);
+        return ret;
+    }
 
     ret = -ENODEV;
 

--- a/xen/arch/arm/cpufreq/rcar_gen3_thermal.c
+++ b/xen/arch/arm/cpufreq/rcar_gen3_thermal.c
@@ -34,6 +34,8 @@
 #include <asm/device.h>
 #include <asm/io.h>
 
+extern bool cpufreq_debug;
+
 extern void mmio_write_32(uintptr_t addr, uint32_t value);
 extern uint32_t mmio_read_32(uintptr_t addr);
 
@@ -484,6 +486,9 @@ static void thermal_zone_device_update(struct rcar_thermal_priv *priv)
 	ret = rcar_gen3_thermal_get_temp(priv, &temp);
 	if (ret)
 		return;
+
+	if (cpufreq_debug)
+		printk("Current CPU temperature: %d mC\n", temp);
 
 	for (i = 0; i < ARRAY_SIZE(trip_points); i++)
 		handle_thermal_trip(temp, i);

--- a/xen/arch/arm/cpufreq/rcar_gen3_thermal.c
+++ b/xen/arch/arm/cpufreq/rcar_gen3_thermal.c
@@ -1,0 +1,571 @@
+/*
+ *  R-Car Gen3 THS/CIVM thermal sensor driver
+ *  Based on drivers/thermal/rcar_thermal.c
+ *
+ * Copyright (C) 2015-2016 Renesas Electronics Corporation.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; version 2 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  General Public License for more details.
+ *
+ *  Based on Linux drivers/thermal/rcar_gen3_thermal.c
+ *  => commit 5570bd640a32b551ed69b9275f5bd90fa21d9c9c
+ *  git://git.kernel.org/pub/scm/linux/kernel/git/horms/renesas-bsp.git
+ *  branch: rcar-3.5.9
+ *
+ *  Xen modification:
+ *  Oleksandr Tyshchenko <Oleksandr_Tyshchenko@epam.com>
+ *  Copyright (C) 2018 EPAM Systems Inc.
+ *
+ */
+
+#include <xen/device_tree.h>
+#include <xen/tasklet.h>
+#include <xen/delay.h>
+#include <xen/err.h>
+#include <xen/vmap.h>
+#include <xen/irq.h>
+#include <xen/shutdown.h>
+#include <asm/device.h>
+#include <asm/io.h>
+
+extern void mmio_write_32(uintptr_t addr, uint32_t value);
+extern uint32_t mmio_read_32(uintptr_t addr);
+
+/* Add missed #define-s to control THS clock */
+/* CPG base address */
+#define	CPG_BASE		(0xE6150000U)
+/* CPG system module stop control 5 */
+#define CPG_SMSTPCR5	(CPG_BASE + 0x0144U)
+/* CPG module stop status 5 */
+#define CPG_MSTPSR5		(CPG_BASE + 0x003CU)
+/* THS/TSC bit in CPG registers */
+#define CPG_THS_BIT		(0x00400000U)
+/* CPG write protect */
+#define CPG_CPGWPR		(CPG_BASE + 0x0900U)
+/* CPG write protect control */
+#define CPG_CPGWPCR		(CPG_BASE + 0x0904U)
+
+#define dev_name(dev) dt_node_full_name(dev_to_dt(dev))
+
+/*
+ * Divide positive or negative dividend by positive or negative divisor
+ * and round to closest integer. Result is undefined for negative
+ * divisors if the dividend variable type is unsigned and for negative
+ * dividends if the divisor variable type is unsigned.
+ */
+#define DIV_ROUND_CLOSEST(x, divisor)(			\
+{							\
+	typeof(x) __x = x;				\
+	typeof(divisor) __d = divisor;			\
+	(((typeof(x))-1) > 0 ||				\
+	 ((typeof(divisor))-1) > 0 ||			\
+	 (((__x) > 0) == ((__d) > 0))) ?		\
+		(((__x) + ((__d) / 2)) / (__d)) :	\
+		(((__x) - ((__d) / 2)) / (__d));	\
+}							\
+)
+
+/* Register offset */
+#define REG_GEN3_CTSR		0x20
+#define REG_GEN3_THCTR		0x20
+#define REG_GEN3_IRQSTR		0x04
+#define REG_GEN3_IRQMSK		0x08
+#define REG_GEN3_IRQCTL		0x0C
+#define REG_GEN3_IRQEN		0x10
+#define REG_GEN3_IRQTEMP1	0x14
+#define REG_GEN3_IRQTEMP2	0x18
+#define REG_GEN3_IRQTEMP3	0x1C
+#define REG_GEN3_TEMP		0x28
+#define REG_GEN3_THCODE1	0x50
+#define REG_GEN3_THCODE2	0x54
+#define REG_GEN3_THCODE3	0x58
+
+#define PTAT_BASE		0xE6198000
+#define REG_GEN3_PTAT1		0x5C
+#define REG_GEN3_PTAT2		0x60
+#define REG_GEN3_PTAT3		0x64
+#define REG_GEN3_THSCP		0x68
+#define REG_GEN3_MAX_SIZE	(REG_GEN3_THSCP + 0x4)
+
+/* THSCP bit */
+#define COR_PARA_VLD		(0x3 << 14)
+
+/* CTSR bit */
+#define PONM1            (0x1 << 8)	/* For H3 ES1.x */
+#define AOUT            (0x1 << 7)
+#define THBGR           (0x1 << 5)
+#define VMEN            (0x1 << 4)
+#define VMST            (0x1 << 1)
+#define THSST           (0x1 << 0)
+
+/* THCTR bit */
+#define PONM2            (0x1 << 6)	/* For H3 ES2.0 and M3 ES1.0 */
+
+#define CTEMP_MASK	0xFFF
+
+#define IRQ_TEMP1_BIT	(0x1 << 0)
+#define IRQ_TEMP2_BIT	(0x1 << 1)
+#define IRQ_TEMP3_BIT	(0x1 << 2)
+#define IRQ_TEMPD1_BIT	(0x1 << 3)
+#define IRQ_TEMPD2_BIT	(0x1 << 4)
+#define IRQ_TEMPD3_BIT	(0x1 << 5)
+
+#define MCELSIUS(temp)			((temp) * 1000)
+#define TEMP_IRQ_SHIFT(tsc_id)	(0x1 << tsc_id)
+#define TEMPD_IRQ_SHIFT(tsc_id)	(0x1 << (tsc_id + 3))
+#define GEN3_FUSE_MASK	0xFFF
+
+/* Equation coefficients for thermal calculation formula.*/
+struct equation_coefs {
+	long a1;
+	long b1;
+	long a2;
+	long b2;
+};
+
+
+struct fuse_factors {
+	int thcode_1;
+	int thcode_2;
+	int thcode_3;
+	int ptat_1;
+	int ptat_2;
+	int ptat_3;
+};
+
+struct rcar_thermal_priv {
+	void __iomem *base;
+	struct device *dev;
+	struct tasklet work;
+	struct fuse_factors factor;
+	struct equation_coefs coef;
+	spinlock_t lock;
+	int id;
+	int irq;
+};
+
+#define rcar_priv_to_dev(priv)		((priv)->dev)
+#define rcar_has_irq_support(priv)	((priv)->irq)
+
+/* Temperature calculation  */
+#define CODETSD(x)		((x) * 1000)
+#define TJ_1 116000L
+#define TJ_3 (-41000L)
+
+#define rcar_thermal_read(p, r) _rcar_thermal_read(p, r)
+static u32 _rcar_thermal_read(struct rcar_thermal_priv *priv, u32 reg)
+{
+	return readl(priv->base + reg);
+}
+
+#define rcar_thermal_write(p, r, d) _rcar_thermal_write(p, r, d)
+static void _rcar_thermal_write(struct rcar_thermal_priv *priv,
+				u32 reg, u32 data)
+{
+	writel(data, priv->base + reg);
+}
+
+static int round_temp(int temp)
+{
+	int tmp1, tmp2;
+	int result = 0;
+
+	tmp1 = ABS(temp) % 1000;
+	tmp2 = ABS(temp) / 1000;
+
+	if (tmp1 < 250)
+		result = CODETSD(tmp2);
+	else if ((tmp1 < 750) && (tmp1 >= 250))
+		result = CODETSD(tmp2) + 500;
+	else
+		result = CODETSD(tmp2) + 1000;
+
+	return ((temp < 0) ? (result * (-1)) : result);
+}
+
+static int thermal_read_fuse_factor(struct rcar_thermal_priv *priv)
+{
+	void __iomem *ptat_base;
+	unsigned int cor_para_value;
+	struct device *dev = rcar_priv_to_dev(priv);
+
+	ptat_base = ioremap_nocache(PTAT_BASE, REG_GEN3_MAX_SIZE);
+	if (!ptat_base) {
+		printk("%s: Cannot map FUSE register\n", dev_name(dev));
+		return -ENOMEM;
+	}
+
+	cor_para_value = readl(ptat_base + REG_GEN3_THSCP) & COR_PARA_VLD;
+
+	/* Checking whether Fuse values have been programmed or not.
+	 * Base on that, it decides using fixed pseudo values or Fuse values.
+	 */
+
+	if (cor_para_value != COR_PARA_VLD) {
+		printk(XENLOG_INFO "%s: is using pseudo fixed values\n", dev_name(dev));
+
+		priv->factor.ptat_1 = 2631;
+		priv->factor.ptat_2 = 1509;
+		priv->factor.ptat_3 = 435;
+		switch (priv->id) {
+		case 0:
+			priv->factor.thcode_1 = 3397;
+			priv->factor.thcode_2 = 2800;
+			priv->factor.thcode_3 = 2221;
+			break;
+		case 1:
+			priv->factor.thcode_1 = 3393;
+			priv->factor.thcode_2 = 2795;
+			priv->factor.thcode_3 = 2216;
+			break;
+		case 2:
+			priv->factor.thcode_1 = 3389;
+			priv->factor.thcode_2 = 2805;
+			priv->factor.thcode_3 = 2237;
+			break;
+		}
+	} else {
+		printk(XENLOG_INFO "%s: is using Fuse values\n", dev_name(dev));
+
+		priv->factor.thcode_1 = rcar_thermal_read(priv,
+						REG_GEN3_THCODE1)
+				& GEN3_FUSE_MASK;
+		priv->factor.thcode_2 = rcar_thermal_read(priv,
+						REG_GEN3_THCODE2)
+				& GEN3_FUSE_MASK;
+		priv->factor.thcode_3 = rcar_thermal_read(priv,
+						REG_GEN3_THCODE3)
+				& GEN3_FUSE_MASK;
+		priv->factor.ptat_1 = readl(ptat_base + REG_GEN3_PTAT1)
+				& GEN3_FUSE_MASK;
+		priv->factor.ptat_2 = readl(ptat_base + REG_GEN3_PTAT2)
+				& GEN3_FUSE_MASK;
+		priv->factor.ptat_3 = readl(ptat_base + REG_GEN3_PTAT3)
+				& GEN3_FUSE_MASK;
+	}
+
+	iounmap(ptat_base);
+
+	return 0;
+}
+
+static void thermal_coefficient_calculation(struct rcar_thermal_priv *priv)
+{
+	int tj_2 = 0;
+	long a1, b1;
+	long a2, b2;
+	long a1_num, a1_den;
+	long a2_num, a2_den;
+
+	tj_2 = (CODETSD((priv->factor.ptat_2 - priv->factor.ptat_3) * 157)
+		/ (priv->factor.ptat_1 - priv->factor.ptat_3)) - CODETSD(41);
+
+	/*
+	 * The following code is to calculate coefficients.
+	 */
+	/* Coefficient a1 and b1 */
+	a1_num = CODETSD(priv->factor.thcode_2 - priv->factor.thcode_3);
+	a1_den = tj_2 - TJ_3;
+	a1 = (10000 * a1_num) / a1_den;
+	b1 = (10000 * priv->factor.thcode_3) - ((a1 * TJ_3) / 1000);
+
+	/* Coefficient a2 and b2 */
+	a2_num = CODETSD(priv->factor.thcode_2 - priv->factor.thcode_1);
+	a2_den = tj_2 - TJ_1;
+	a2 = (10000 * a2_num) / a2_den;
+	b2 = (10000 * priv->factor.thcode_1) - ((a2 * TJ_1) / 1000);
+
+	priv->coef.a1 = DIV_ROUND_CLOSEST(a1, 10);
+	priv->coef.b1 = DIV_ROUND_CLOSEST(b1, 10);
+	priv->coef.a2 = DIV_ROUND_CLOSEST(a2, 10);
+	priv->coef.b2 = DIV_ROUND_CLOSEST(b2, 10);
+}
+
+int thermal_temp_converter(struct equation_coefs coef,
+					int temp_code)
+{
+	int temp, temp1, temp2;
+
+	temp1 = MCELSIUS((CODETSD(temp_code) - coef.b1)) / coef.a1;
+	temp2 = MCELSIUS((CODETSD(temp_code) - coef.b2)) / coef.a2;
+	temp = (temp1 + temp2) / 2;
+
+	return round_temp(temp);
+}
+
+int thermal_celsius_to_temp(struct equation_coefs coef,
+					int ctemp)
+{
+	int temp_code, temp1, temp2;
+
+	temp1 = (((ctemp * coef.a1) / 1000) + coef.b1) / 1000;
+	temp2 = (((ctemp * coef.a2) / 1000) + coef.b2) / 1000;
+	temp_code = (temp1 + temp2) / 2;
+
+	return temp_code;
+}
+
+/*
+ *		Zone device functions
+ */
+static int rcar_gen3_thermal_update_temp(struct rcar_thermal_priv *priv)
+{
+	u32 ctemp;
+	unsigned long flags;
+	int temp_cel, temp_code;
+
+	spin_lock_irqsave(&priv->lock, flags);
+
+	ctemp = rcar_thermal_read(priv, REG_GEN3_TEMP) & CTEMP_MASK;
+	if (rcar_has_irq_support(priv)) {
+		temp_cel = thermal_temp_converter(priv->coef, ctemp);
+
+		/* set the interrupts to exceed the temperature */
+		temp_code = thermal_celsius_to_temp(priv->coef,
+						    temp_cel + MCELSIUS(1));
+		rcar_thermal_write(priv, REG_GEN3_IRQTEMP1, temp_code);
+
+		/* set the interrupts to fall below the temperature */
+		temp_code = thermal_celsius_to_temp(priv->coef,
+						    temp_cel - MCELSIUS(1));
+		rcar_thermal_write(priv, REG_GEN3_IRQTEMP2, temp_code);
+	}
+
+	spin_unlock_irqrestore(&priv->lock, flags);
+
+	return 0;
+}
+
+static int __maybe_unused rcar_gen3_thermal_get_temp(void *devdata, int *temp)
+{
+	struct rcar_thermal_priv *priv = devdata;
+	int ctemp;
+	unsigned long flags;
+	u32 ctemp_code;
+
+	spin_lock_irqsave(&priv->lock, flags);
+	ctemp_code = rcar_thermal_read(priv, REG_GEN3_TEMP) & CTEMP_MASK;
+	ctemp = thermal_temp_converter(priv->coef, ctemp_code);
+	spin_unlock_irqrestore(&priv->lock, flags);
+
+	if ((ctemp < MCELSIUS(-40)) || (ctemp > MCELSIUS(125))) {
+		struct device *dev = rcar_priv_to_dev(priv);
+
+		printk(XENLOG_WARNING "%s: Temperature is not measured correctly!\n",
+				dev_name(dev));
+
+		return -EIO;
+	}
+
+	*temp = ctemp;
+
+	return 0;
+}
+
+/* Applicable for both M3 1.x and H3 ES2.0, but not for H3 1.x */
+static int rcar_gen3_r8a7796_thermal_init(struct rcar_thermal_priv *priv)
+{
+	unsigned long flags;
+	unsigned long reg_val;
+
+	spin_lock_irqsave(&priv->lock, flags);
+	reg_val = rcar_thermal_read(priv, REG_GEN3_THCTR);
+	reg_val &= ~PONM2;
+	rcar_thermal_write(priv, REG_GEN3_THCTR, reg_val);
+	udelay(1000);
+	rcar_thermal_write(priv, REG_GEN3_IRQCTL, 0x3F);
+	rcar_thermal_write(priv, REG_GEN3_IRQMSK, 0);
+	rcar_thermal_write(priv, REG_GEN3_IRQEN,
+			   IRQ_TEMP1_BIT | IRQ_TEMPD2_BIT);
+	reg_val = rcar_thermal_read(priv, REG_GEN3_THCTR);
+	reg_val |= THSST;
+	rcar_thermal_write(priv, REG_GEN3_THCTR, reg_val);
+
+	spin_unlock_irqrestore(&priv->lock, flags);
+
+	return 0;
+}
+
+/*
+ *		Interrupt
+ */
+#define rcar_thermal_irq_enable(p)	_rcar_thermal_irq_ctrl(p, 1)
+#define rcar_thermal_irq_disable(p)	_rcar_thermal_irq_ctrl(p, 0)
+static void _rcar_thermal_irq_ctrl(struct rcar_thermal_priv *priv, int enable)
+{
+	unsigned long flags;
+
+	if (!rcar_has_irq_support(priv))
+		return;
+
+	spin_lock_irqsave(&priv->lock, flags);
+	rcar_thermal_write(priv, REG_GEN3_IRQSTR, 0);
+	rcar_thermal_write(priv, REG_GEN3_IRQMSK,
+		enable ? (IRQ_TEMP1_BIT | IRQ_TEMPD2_BIT) : 0);
+	spin_unlock_irqrestore(&priv->lock, flags);
+}
+
+static void rcar_gen3_thermal_work(unsigned long data)
+{
+	struct rcar_thermal_priv *priv = (struct rcar_thermal_priv *)data;
+
+	rcar_gen3_thermal_update_temp(priv);
+	/* TODO Here we must read current temp and make sure it doesn't exceed limit. */
+	rcar_thermal_irq_enable(priv);
+}
+
+static void rcar_gen3_thermal_irq(int irq, void *data,
+		struct cpu_user_regs *regs)
+{
+	struct rcar_thermal_priv *priv = data;
+	unsigned long flags;
+	int status;
+
+	spin_lock_irqsave(&priv->lock, flags);
+	status = rcar_thermal_read(priv, REG_GEN3_IRQSTR);
+	rcar_thermal_write(priv, REG_GEN3_IRQSTR, 0);
+	spin_unlock_irqrestore(&priv->lock, flags);
+
+	if (status == 0)
+		return;
+
+	if (status & (IRQ_TEMP1_BIT | IRQ_TEMPD2_BIT)) {
+		rcar_thermal_irq_disable(priv);
+		tasklet_schedule(&priv->work);
+	}
+}
+
+static const struct dt_device_match rcar_thermal_dt_ids[] __initconst = {
+	{ .compatible = "renesas,thermal-r8a7795", },
+	{ .compatible = "renesas,thermal-r8a7796", },
+	{ },
+};
+
+static int __init rcar_gen3_thermal_probe(struct dt_device_node *np)
+{
+	struct rcar_thermal_priv *priv;
+	struct device *dev = &np->dev;
+	int ret, i, irq_cnt, irqs[3];
+	uint64_t addr, size;
+
+	priv = xzalloc(struct rcar_thermal_priv);
+	if (!priv)
+		return -ENOMEM;
+
+	priv->dev = dev;
+
+	/* Preliminary check for IRQ(s) to present */
+	irq_cnt = dt_number_of_irq(np);
+	if (!irq_cnt || irq_cnt > ARRAY_SIZE(irqs)) {
+		printk("%s: Got wrong IRQ count!\n", dev_name(dev));
+		ret = -ENODEV;
+		goto err_free;
+	}
+	priv->irq = 1;
+
+	ret = dt_device_get_address(np, 0, &addr, &size);
+	if (ret) {
+		printk("%s: Failed to get MMIO base address\n", dev_name(dev));
+		goto err_free;
+	}
+
+	priv->base = ioremap_nocache(addr, size);
+	if (!priv->base) {
+		printk("%s: Failed to map MMIO range\n", dev_name(dev));
+		ret = -ENOMEM;
+		goto err_free;
+	}
+
+	spin_lock_init(&priv->lock);
+	tasklet_init(&priv->work, rcar_gen3_thermal_work, (unsigned long)priv);
+
+	priv->id = dt_alias_get_id(dev->of_node, "tsc");
+
+	rcar_gen3_r8a7796_thermal_init(priv);
+	ret = thermal_read_fuse_factor(priv);
+	if (ret)
+		goto err_iounmap;
+
+	thermal_coefficient_calculation(priv);
+	ret = rcar_gen3_thermal_update_temp(priv);
+	if (ret < 0)
+		goto err_iounmap;
+
+	if (rcar_has_irq_support(priv)) {
+		for (i = 0; i < irq_cnt; i++) {
+			irqs[i] = platform_get_irq(np, i);
+			if (irqs[i] < 0) {
+				printk("%s: Failed to get IRQ index %d\n", dev_name(dev), i);
+				goto err_release;
+			}
+
+			ret = request_irq(irqs[i], IRQF_SHARED, rcar_gen3_thermal_irq,
+					dev_name(dev), priv);
+			if (ret) {
+				printk("%s: Failed to request IRQ %d\n", dev_name(dev), irqs[i]);
+				goto err_release;
+			}
+		}
+		rcar_thermal_irq_enable(priv);
+	}
+
+	printk(XENLOG_INFO "%s: Thermal sensor probed id%d\n",
+			dev_name(dev), priv->id);
+
+	return 0;
+
+err_release:
+	while (i--)
+		release_irq(irqs[i], priv);
+err_iounmap:
+	tasklet_kill(&priv->work);
+	iounmap(priv->base);
+err_free:
+	xfree(priv);
+
+	return ret;
+}
+
+static inline void cpg_write(uintptr_t regadr, uint32_t regval)
+{
+	uint32_t value = (regval);
+	mmio_write_32((uintptr_t)CPG_CPGWPR, ~value);
+	mmio_write_32(regadr, value);
+}
+
+static void rcar_gen3_thermal_enable_clock(void)
+{
+	/* Is the clock supply to the CPG disabled ? */
+	while ((mmio_read_32(CPG_MSTPSR5) & CPG_THS_BIT) != 0U) {
+		/* Enables the clock supply to the CPG. */
+		cpg_write(CPG_SMSTPCR5, mmio_read_32(CPG_SMSTPCR5) & (~CPG_THS_BIT));
+	}
+}
+
+static int __init rcar_gen3_thermal_init(struct dt_device_node *np,
+		const void *data)
+{
+	int ret;
+
+	rcar_gen3_thermal_enable_clock();
+
+	ret = rcar_gen3_thermal_probe(np);
+	if (ret) {
+		printk(XENLOG_ERR "%s: failed to init R-Car Gen3 THS (%d)\n",
+				dev_name(&np->dev), ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+DT_DEVICE_START(rcar_gen3_thermal, "R-Car Gen3 THS", DEVICE_THS)
+	.dt_match = rcar_thermal_dt_ids,
+	.init = rcar_gen3_thermal_init,
+DT_DEVICE_END

--- a/xen/arch/arm/cpufreq/scpi_cpufreq.c
+++ b/xen/arch/arm/cpufreq/scpi_cpufreq.c
@@ -37,6 +37,19 @@ extern int dev_pm_opp_set_rate(unsigned long target_freq);
 
 extern struct device *get_cpu_device(unsigned int cpu);
 
+/*
+ * To protect changing frequency driven by both CPUFreq governor and
+ * CPU throttling work.
+ */
+static DEFINE_SPINLOCK(scpi_lock);
+/*
+ * To signal that turbo frequencies are not allowed to be set
+ * (CPU throttling is present).
+ */
+static bool turbo_prohibited = false;
+/* CPU which throttling affects */
+static unsigned int target_cpu = 0;
+
 struct scpi_cpufreq_data
 {
     struct processor_performance *perf;
@@ -132,8 +145,9 @@ static int scpi_cpufreq_set(unsigned int cpu, unsigned int freq)
     return 0;
 }
 
-static int scpi_cpufreq_target(struct cpufreq_policy *policy,
-                               unsigned int target_freq, unsigned int relation)
+static int scpi_cpufreq_target_unlocked(struct cpufreq_policy *policy,
+                                        unsigned int target_freq,
+                                        unsigned int relation)
 {
     struct scpi_cpufreq_data *data = cpufreq_driver_data[policy->cpu];
     struct processor_performance *perf;
@@ -147,7 +161,7 @@ static int scpi_cpufreq_target(struct cpufreq_policy *policy,
     if ( unlikely(!data || !data->perf || !data->freq_table || !data->info) )
         return -ENODEV;
 
-    if ( policy->turbo == CPUFREQ_TURBO_DISABLED )
+    if ( policy->turbo == CPUFREQ_TURBO_DISABLED || turbo_prohibited )
         if ( target_freq > policy->cpuinfo.second_max_freq )
             target_freq = policy->cpuinfo.second_max_freq;
 
@@ -183,6 +197,18 @@ static int scpi_cpufreq_target(struct cpufreq_policy *policy,
 
     perf->state = next_perf_state;
     policy->cur = freqs.new;
+
+    return result;
+}
+
+static int scpi_cpufreq_target(struct cpufreq_policy *policy,
+                               unsigned int target_freq, unsigned int relation)
+{
+    int result;
+
+    spin_lock(&scpi_lock);
+    result = scpi_cpufreq_target_unlocked(policy, target_freq, relation);
+    spin_unlock(&scpi_lock);
 
     return result;
 }
@@ -354,6 +380,12 @@ static int scpi_cpufreq_cpu_init(struct cpufreq_policy *policy)
      */
     policy->resume = 1;
 
+    /*
+     * TODO: We assume that we do DVFS only for A57 cluster, where all
+     * involved CPUs share the same clock. But this should be reconsidered.
+     */
+    target_cpu = policy->cpu;
+
     return result;
 
 err_freqfree:
@@ -389,6 +421,46 @@ static struct cpufreq_driver scpi_cpufreq_driver = {
     .exit   = scpi_cpufreq_cpu_exit,
     .update = scpi_cpufreq_update,
 };
+
+int scpi_cpufreq_throttle(bool enable)
+{
+    struct cpufreq_policy *policy;
+    int result = 0;
+
+    policy = per_cpu(cpufreq_cpu_policy, target_cpu);
+    if ( !policy )
+       return 0;
+
+    if ( !enable )
+    {
+        /* Just allow to set any frequencies... */
+        turbo_prohibited = false;
+    }
+    else
+    {
+        spin_lock(&scpi_lock);
+        /* Check if we are running on turbo frequency */
+        if ( policy->cur > policy->cpuinfo.second_max_freq )
+        {
+            /* Set max non-turbo frequency */
+            result = scpi_cpufreq_set(policy->cpu,
+                                      policy->cpuinfo.second_max_freq);
+            if ( result < 0 )
+            {
+                spin_unlock(&scpi_lock);
+                return result;
+            }
+        }
+        /* Signal that turbo frequencies are not allowed to be set */
+        turbo_prohibited = true;
+        spin_unlock(&scpi_lock);
+    }
+
+    printk(XENLOG_INFO "cpu%u: %s CPU throttling\n", policy->cpu,
+           turbo_prohibited ? "Enable" : "Disable");
+
+    return 0;
+}
 
 int __init scpi_cpufreq_register_driver(void)
 {

--- a/xen/common/device_tree.c
+++ b/xen/common/device_tree.c
@@ -427,6 +427,26 @@ struct dt_device_node *dt_find_node_by_alias(const char *alias)
     return NULL;
 }
 
+int dt_alias_get_id(struct dt_device_node *np, const char *stem)
+{
+    struct dt_alias_prop *app;
+    int id = -ENODEV;
+
+    list_for_each_entry( app, &aliases_lookup, link )
+    {
+        if ( strcmp(app->stem, stem) != 0 )
+            continue;
+
+        if ( np == app->np )
+        {
+            id = app->id;
+            break;
+        }
+    }
+
+    return id;
+}
+
 const struct dt_device_match *
 dt_match_node(const struct dt_device_match *matches,
               const struct dt_device_node *node)

--- a/xen/include/asm-arm/device.h
+++ b/xen/include/asm-arm/device.h
@@ -38,6 +38,7 @@ enum device_class
     DEVICE_GIC,
     DEVICE_COPROC,
     DEVICE_MAILBOX,
+    DEVICE_THS,
     /* Use for error */
     DEVICE_UNKNOWN,
 };

--- a/xen/include/xen/device_tree.h
+++ b/xen/include/xen/device_tree.h
@@ -608,6 +608,16 @@ struct dt_device_node *dt_find_node_by_alias(const char *alias);
  */
 struct dt_device_node *dt_find_node_by_path(const char *path);
 
+/**
+ * dt_alias_get_id - Get alias id for the given device_node
+ * @np:		Pointer to the given device_node
+ * @stem:	Alias stem of the given device_node
+ *
+ * The function travels the lookup table to get the alias id for the given
+ * device_node and alias stem. It returns the alias id if found.
+ */
+int dt_alias_get_id(struct dt_device_node *np, const char *stem);
+
 
 /**
  * dt_find_node_by_gpath - Same as dt_find_node_by_path but retrieve the


### PR DESCRIPTION
This pull request adds thermal support to Xen. Currently Xen is able to manage only one thermal sensor. It discovers it from device-tree, configures it and controls it's temperature in the runtime.
If THS temperature exceeds limits, Xen performs predefined actions such as CPU throttling and rebooting the whole system. What I would like to say that Xen is a *temporary place* for this stuff. Thermal as well as DVFS will be moved to SCP (ARM TF).

P.S. As Xen assumes that THS it is managing is a CPU thermal sensor, we have to leave in the device-tree THS3 in "enabled state", others must be disabled (already done).