### PR TITLE
Adjust guest memory map

### DIFF
--- a/xen/include/public/arch-arm.h
+++ b/xen/include/public/arch-arm.h
@@ -432,8 +432,8 @@ typedef uint64_t xen_callback_t;
 
 #define GUEST_RAM_BANKS   2
 
-#define GUEST_RAM0_BASE   xen_mk_ullong(0x40000000) /* 3GB of low RAM @ 1GB */
-#define GUEST_RAM0_SIZE   xen_mk_ullong(0xc0000000)
+#define GUEST_RAM0_BASE   xen_mk_ullong(0x40000000) /* 2GB of low RAM @ 1GB */
+#define GUEST_RAM0_SIZE   xen_mk_ullong(0x80000000)
 
 #define GUEST_RAM1_BASE   xen_mk_ullong(0x0200000000) /* 1016GB of RAM @ 8GB */
 #define GUEST_RAM1_SIZE   xen_mk_ullong(0xfe00000000)


### PR DESCRIPTION
In order to get running guests with access to IO we have to adjust
XEN guest domain memory map to one specific for an exact platform.
In our case R-CAR Gen3 has IO mapped at 0xc0000000 with 1GB size,
so we limit RAM0_SIZE to 2GB at 0x40000000.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>