### PR TITLE
ipmmu-vmsa: Fix ipmmu_ctx_write2() execution for non-shared case

### DIFF
--- a/xen/drivers/passthrough/arm/ipmmu-vmsa.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa.c
@@ -668,9 +668,9 @@ static void ipmmu_ctx_write2(struct ipmmu_vmsa_domain *domain, unsigned int reg,
 
 	list_for_each_entry(io_domain, &xen_domain->contexts, list)
 		ipmmu_ctx_write1(to_vmsa_domain(io_domain), reg, data);
+#endif
 
 	ipmmu_ctx_write(domain, reg, data);
-#endif
 }
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>