### PR TITLE
hack: Rewrite injecting GSX irq logic

### DIFF
--- a/xen/arch/arm/gic.c
+++ b/xen/arch/arm/gic.c
@@ -27,6 +27,7 @@
 #include <xen/list.h>
 #include <xen/device_tree.h>
 #include <xen/acpi.h>
+#include <xen/vmap.h>
 #include <asm/p2m.h>
 #include <asm/domain.h>
 #include <asm/platform.h>
@@ -835,6 +836,73 @@ void init_maintenance_interrupt(void)
 {
     request_irq(gic_hw_ops->info->maintenance_irq, 0, maintenance_interrupt,
                 "irq-maintenance", NULL);
+}
+
+#define GSX_IRQ_NUM                151
+#define GSX_REG_BASE               0xfd000000
+#define GSX_REG_SIZE               0x00002000
+#define GSX_IRQ_CNTS_REG           0x00001238
+#define GSX_IRQ_CNTS_SHIFT         12
+#define GSX_GUEST_IRQ_CNT_SHIFT    14
+#define GSX_HOST_IRQ_CNT_MASK      0x3fff
+#define GSX_IRQ_STATUS_REG         0x00000ac8
+#define GSX_IRQ_STATUS_EVENT_MASK  0x00000004
+#define GSX_IRQ_CLEAR_REG          0x00000ac8
+#define GSX_IRQ_CLEAR_MASK         0xfffffffb
+
+static void __iomem *gsx_reg_base = NULL;
+
+static u16 guest_irq_cnt, host_irq_cnt;
+
+static void gsx_interrupt(int irq, void *dev_id, struct cpu_user_regs *regs)
+{
+    struct domain *d;
+    uint32_t irq_cnts, irq_status;
+
+    irq_status = readl_relaxed(gsx_reg_base + GSX_IRQ_STATUS_REG);
+    irq_cnts = readq_relaxed(gsx_reg_base + GSX_IRQ_CNTS_REG) >> GSX_IRQ_CNTS_SHIFT;
+
+    if ( irq_status & GSX_IRQ_STATUS_EVENT_MASK )
+        writel_relaxed(GSX_IRQ_CLEAR_MASK, gsx_reg_base + GSX_IRQ_CLEAR_REG);
+
+    if ( host_irq_cnt != (irq_cnts & GSX_HOST_IRQ_CNT_MASK) )
+    {
+        d = get_domain_by_id(1);
+        vgic_vcpu_inject_irq(d->vcpu[0], irq);
+        host_irq_cnt = irq_cnts & GSX_HOST_IRQ_CNT_MASK;
+    }
+
+    if ( guest_irq_cnt != (irq_cnts >> GSX_GUEST_IRQ_CNT_SHIFT) )
+    {
+        for_each_domain ( d )
+        {
+            if ( d->domain_id < 2 )
+                continue;
+
+            vgic_vcpu_inject_irq(d->vcpu[0], irq);
+            break;
+        }
+        guest_irq_cnt = irq_cnts >> GSX_GUEST_IRQ_CNT_SHIFT;
+    }
+}
+
+void init_gsx_interrupt(void)
+{
+    int ret;
+
+    gsx_reg_base = ioremap_nocache(GSX_REG_BASE, GSX_REG_SIZE);
+    if ( !gsx_reg_base )
+    {
+        printk("failed to map GSX MMIO range\n");
+        return;
+    }
+
+    ret = request_irq(GSX_IRQ_NUM, 0, gsx_interrupt, "gsx irq", NULL);
+    if ( ret )
+    {
+        iounmap(gsx_reg_base);
+        printk("failed to request GSX IRQ\n");
+    }
 }
 
 int gic_make_hwdom_dt_node(const struct domain *d,

--- a/xen/arch/arm/setup.c
+++ b/xen/arch/arm/setup.c
@@ -804,6 +804,7 @@ void __init start_xen(unsigned long boot_phys_offset,
     xsm_dt_init();
 
     init_maintenance_interrupt();
+    init_gsx_interrupt();
     init_timer_interrupt();
 
     timer_init();

--- a/xen/include/asm-arm/gic.h
+++ b/xen/include/asm-arm/gic.h
@@ -240,6 +240,7 @@ extern void gic_clear_pending_irqs(struct vcpu *v);
 extern int gic_events_need_delivery(void);
 
 extern void init_maintenance_interrupt(void);
+extern void init_gsx_interrupt(void);
 extern void gic_raise_guest_irq(struct vcpu *v, unsigned int irq,
         unsigned int priority);
 extern void gic_raise_inflight_irq(struct vcpu *v, unsigned int virtual_irq);


### PR DESCRIPTION
Handle GSX irq separately from other guest irqs. Now Xen subscribes to
GSX irq and performs all GSX related actions in an extra interrupt handler.
Xen reads both irq counters (host and guest) and injects GSX irqs
to required domains.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>