### PR TITLE
xen/arm: Inject GSX irq to all subscribed guest domains

### DIFF
--- a/xen/arch/arm/irq.c
+++ b/xen/arch/arm/irq.c
@@ -30,11 +30,17 @@
 static unsigned int local_irqs_type[NR_LOCAL_IRQS];
 static DEFINE_SPINLOCK(local_irqs_type_lock);
 
+const int gsx_irq_num = 151;
+
+/* Total context count is 8, but the 8th context is always used by host */
+#define GSX_GUESTS_CNT    7
+
 /* Describe an IRQ assigned to a guest */
 struct irq_guest
 {
     struct domain *d;
     unsigned int virq;
+    struct domain *gsx_guests[GSX_GUESTS_CNT];
 };
 
 static void ack_none(struct irq_desc *irq)
@@ -182,6 +188,74 @@ int request_irq(unsigned int irq, unsigned int irqflags,
     return retval;
 }
 
+void remove_gsx_guest(struct domain *d)
+{
+    struct irq_desc *desc = irq_to_desc(gsx_irq_num);
+    struct irq_guest *info = irq_get_guest_info(desc);
+    unsigned long flags;
+    int i;
+
+    spin_lock_irqsave(&desc->lock, flags);
+
+    /* clear a slot occupied by gsx guest */
+    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
+    {
+        if ( !info->gsx_guests[i] )
+            continue;
+
+        if ( info->gsx_guests[i] == d )
+        {
+            info->gsx_guests[i] = NULL;
+            printk("Removed GSX guest domain %u\n", d->domain_id);
+            break;
+        }
+    }
+
+    spin_unlock_irqrestore(&desc->lock, flags);
+
+    BUG_ON(i == ARRAY_SIZE(info->gsx_guests));
+}
+
+/* called with desc->lock held */
+static void add_gsx_guest(struct domain *d, struct irq_guest *info)
+{
+    int i;
+
+    /* find an empty slot to put gsx guest in it */
+    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
+    {
+        if ( info->gsx_guests[i] )
+           continue;
+
+        info->gsx_guests[i] = d;
+        printk("Added GSX guest domain %u\n", d->domain_id);
+        break;
+    }
+
+    BUG_ON(i == ARRAY_SIZE(info->gsx_guests));
+}
+
+/* called with desc->lock held */
+static void init_gsx_guests(struct domain *d, struct irq_guest *info)
+{
+    memset(info->gsx_guests, 0, sizeof(info->gsx_guests));
+}
+
+/* called with desc->lock held */
+static void inject_to_gsx_guests(struct irq_guest *info)
+{
+    int i;
+
+    /* inject irq to all gsx guests */
+    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
+    {
+        if ( !info->gsx_guests[i] )
+            continue;
+
+        vgic_vcpu_inject_spi(info->gsx_guests[i], info->virq);
+    }
+}
+
 /* Dispatch an interrupt */
 void do_IRQ(struct cpu_user_regs *regs, unsigned int irq, int is_fiq)
 {
@@ -224,6 +298,9 @@ void do_IRQ(struct cpu_user_regs *regs, unsigned int irq, int is_fiq)
          * guests.
 	 */
         vgic_vcpu_inject_spi(info->d, info->virq);
+        if ( irq == gsx_irq_num )
+            inject_to_gsx_guests(info);
+
         goto out_no_end;
     }
 
@@ -479,12 +556,18 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
         if ( test_bit(_IRQ_GUEST, &desc->status) )
         {
             struct domain *ad = irq_get_domain(desc);
+            struct irq_guest *ainfo = irq_get_guest_info(desc);
 
             if ( d != ad )
             {
-                printk(XENLOG_G_ERR "IRQ %u is already used by domain %u\n",
-                       irq, ad->domain_id);
-                retval = -EBUSY;
+                if ( irq != gsx_irq_num )
+                {
+                    printk(XENLOG_G_ERR "IRQ %u is already used by domain %u\n",
+                           irq, ad->domain_id);
+                    retval = -EBUSY;
+                }
+                else
+                    add_gsx_guest(d, ainfo);
             }
             else if ( irq_get_guest_info(desc)->virq != virq )
             {
@@ -500,6 +583,11 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
             retval = -EBUSY;
         }
         goto out;
+    }
+    else
+    {
+        if ( irq == gsx_irq_num )
+            init_gsx_guests(d, info);
     }
 
     retval = __setup_irq(desc, 0, action);

--- a/xen/arch/arm/vgic.c
+++ b/xen/arch/arm/vgic.c
@@ -169,6 +169,9 @@ void register_vgic_ops(struct domain *d, const struct vgic_ops *ops)
    d->arch.vgic.handler = ops;
 }
 
+extern const int gsx_irq_num;
+extern void remove_gsx_guest(struct domain *d);
+
 void domain_vgic_free(struct domain *d)
 {
     int i;
@@ -177,6 +180,9 @@ void domain_vgic_free(struct domain *d)
     for ( i = 0; i < (d->arch.vgic.nr_spis); i++ )
     {
         struct pending_irq *p = spi_to_pending(d, i + 32);
+
+        if ( p->irq == gsx_irq_num )
+            remove_gsx_guest(d);
 
         if ( p->desc )
         {


### PR DESCRIPTION
We need to take care of injecting GSX irq to guest domains
that run GPU, since host driver doesn't send corresponding event
to guest driver anymore.

The patch was done in a way to inject GSX irq only to guest domains
that really required it. We assume, if domain config file contains
corresponding irq number then most likely it will run GPU.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>