### PR TITLE
xen/arm: Remove BUG_ON from remove_gsx_guest func

### DIFF
--- a/xen/arch/arm/irq.c
+++ b/xen/arch/arm/irq.c
@@ -214,8 +214,6 @@ void remove_gsx_guest(struct domain *d)
     }
 
     spin_unlock_irqrestore(&desc->lock, flags);
-
-    BUG_ON(i == ARRAY_SIZE(info->gsx_guests));
 }
 
 /* called with desc->lock held */


### PR DESCRIPTION
The point is that BUG_ON is fired when rebooting DomD, since no
occupied slot has been found during iterating gsx_guests array.
But nothing wrong happens here, since driver domain is NOT a GSX guest
and as the result gsx_guests array doesn't contain any pointer to it.

If we could recognize driver domain id properly (not just assuming that
driver domain id is always equal to 1) we would add an approprite check
before invoking remove_gsx_guest.

This patch doesn't mean to make reboot DomD feature fully supported,
but at least Xen won't complain about doing that.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>