### PR TITLE
[RFC] IPMMU support for S2RAM and others

### DIFF
--- a/xen/drivers/passthrough/arm/ipmmu-vmsa-plat.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa-plat.c
@@ -100,6 +100,17 @@ static const struct rcar_sysc_ch rcar_sysc_chs[2] = {
 
 #define dev_name(dev) dt_node_full_name(dev_to_dt(dev))
 
+static u32 syscier_val, syscimr_val;
+
+void rcar_sysc_restore(void)
+{
+	ASSERT(system_state == SYS_STATE_resume);
+
+	/* Re-enable interrupt sources when resuming */
+	writel(syscimr_val, rcar_sysc_base + SYSCIMR);
+	writel(syscier_val, rcar_sysc_base + SYSCIER);
+}
+
 static int rcar_sysc_init(void)
 {
 	u32 syscier, syscimr;
@@ -132,6 +143,9 @@ static int rcar_sysc_init(void)
 
 	/* SYSC needs all interrupt sources enabled to control power */
 	writel(syscier, rcar_sysc_base + SYSCIER);
+
+	syscier_val = syscier;
+	syscimr_val = syscimr;
 
 	return 0;
 }

--- a/xen/drivers/passthrough/arm/ipmmu-vmsa-plat.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa-plat.c
@@ -100,7 +100,7 @@ static const struct rcar_sysc_ch rcar_sysc_chs[2] = {
 
 #define dev_name(dev) dt_node_full_name(dev_to_dt(dev))
 
-static int __init rcar_sysc_init(void)
+static int rcar_sysc_init(void)
 {
 	u32 syscier, syscimr;
 	int i;
@@ -136,7 +136,7 @@ static int __init rcar_sysc_init(void)
 	return 0;
 }
 
-static bool __init rcar_sysc_power_is_off(const struct rcar_sysc_ch *sysc_ch)
+static bool rcar_sysc_power_is_off(const struct rcar_sysc_ch *sysc_ch)
 {
 	unsigned int status;
 
@@ -147,7 +147,7 @@ static bool __init rcar_sysc_power_is_off(const struct rcar_sysc_ch *sysc_ch)
 	return false;
 }
 
-static int __init rcar_sysc_power_on(const struct rcar_sysc_ch *sysc_ch)
+static int rcar_sysc_power_on(const struct rcar_sysc_ch *sysc_ch)
 {
 	unsigned int status;
 	int ret = 0, i, j;
@@ -212,7 +212,7 @@ static uint32_t ipmmu_get_mmu_pd(struct dt_device_node *np)
  * they are in power-off state during booting, therefore they must be
  * explicitly powered on before initializing.
  */
-static int __init ipmmu_power_on(struct dt_device_node *np)
+static int ipmmu_power_on(struct dt_device_node *np)
 {
 	int i, pd, ret = -ENODEV;
 
@@ -276,7 +276,7 @@ bool ipmmu_is_mmu_tlb_disable_needed(struct dt_device_node *np)
 	return false;
 }
 
-int __init ipmmu_preinit(struct dt_device_node *np)
+int ipmmu_preinit(struct dt_device_node *np)
 {
 	return ipmmu_power_on(np);
 }

--- a/xen/drivers/passthrough/arm/ipmmu-vmsa.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa.c
@@ -2316,8 +2316,12 @@ static void ipmmu_resume(void)
 	spin_lock(&ipmmu_devices_lock);
 
 	list_for_each_entry(mmu, &ipmmu_devices, list) {
-		int ctx;
+		int ctx, rc;
 		unsigned int i;
+
+		rc = ipmmu_preinit(mmu->dev->of_node);
+		if (rc)
+			dev_err(mmu->dev, "failed to preinit IPMMU (%d)\n", rc);
 
 		if (ipmmu_is_root(mmu)) {
 #ifdef CONFIG_RCAR_IPMMU_PGT_IS_SHARED

--- a/xen/drivers/passthrough/arm/ipmmu-vmsa.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa.c
@@ -1086,6 +1086,9 @@ static irqreturn_t ipmmu_domain_irq(struct ipmmu_vmsa_domain *domain)
 	if (!(status & (IMSTR_PF | IMSTR_TF)))
 		return IRQ_NONE;
 
+	/* Flush the TLB as required when IPMMU translation error occurred. */
+	ipmmu_tlb_invalidate(domain);
+
 	/*
 	 * Try to handle page faults and translation faults.
 	 *

--- a/xen/drivers/passthrough/arm/ipmmu-vmsa.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa.c
@@ -49,6 +49,7 @@
 
 extern int ipmmu_preinit(struct dt_device_node *np);
 extern bool ipmmu_is_mmu_tlb_disable_needed(struct dt_device_node *np);
+extern void rcar_sysc_restore(void);
 
 /***** Start of Xen specific code *****/
 
@@ -2312,6 +2313,8 @@ static void ipmmu_resume(void)
 {
 #ifdef CONFIG_RCAR_DDR_BACKUP
 	struct ipmmu_vmsa_device *mmu = NULL;
+
+	rcar_sysc_restore();
 
 	spin_lock(&ipmmu_devices_lock);
 

--- a/xen/drivers/passthrough/arm/ipmmu-vmsa.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa.c
@@ -984,13 +984,6 @@ static int ipmmu_domain_init_context(struct ipmmu_vmsa_domain *domain)
 				~(IMBUSCR_DVM | IMBUSCR_BUSSEL_MASK));
 
 	/*
-	 * IMSAUXCTLR
-	 * Use stage 2 translation table format.
-	 */
-	ipmmu_ctx_write_root(domain, IMSAUXCTLR, ipmmu_ctx_read_root(domain, IMSAUXCTLR) |
-		IMSAUXCTLR_S2PTE);
-
-	/*
 	 * IMSTR
 	 * Clear all interrupt flags.
 	 */
@@ -2062,6 +2055,12 @@ static int ipmmu_probe(struct platform_device *pdev)
 		}
 
 		ipmmu_device_reset(mmu);
+
+#ifdef CONFIG_RCAR_IPMMU_PGT_IS_SHARED
+		/* Use stage 2 translation table format */
+		ipmmu_write(mmu, IMSAUXCTLR,
+				ipmmu_read(mmu, IMSAUXCTLR) | IMSAUXCTLR_S2PTE);
+#endif
 	} else {
 		/* Only IPMMU caches are affected */
 		mmu->is_mmu_tlb_disabled = ipmmu_is_mmu_tlb_disable_needed(pdev);

--- a/xen/drivers/passthrough/arm/ipmmu-vmsa.c
+++ b/xen/drivers/passthrough/arm/ipmmu-vmsa.c
@@ -1224,13 +1224,6 @@ static int ipmmu_attach_device(struct iommu_domain *io_domain,
 #if 0
 		ret = ipmmu_domain_init_context(domain);
 #endif
-		/*
-		 * Here we have to disable IPMMU TLB cache function of IPMMU caches
-		 * that do require such action.
-		 */
-		if (domain->mmus[0]->is_mmu_tlb_disabled)
-			ipmmu_ctx_write_cache(domain, IMSCTLR,
-					ipmmu_ctx_read_root(domain, IMSCTLR) | IMSCTLR_DISCACHE);
 
 		ipmmu_ctx_write_cache(domain, IMCTR,
 				ipmmu_ctx_read_root(domain, IMCTR) | IMCTR_FLUSH);
@@ -2064,6 +2057,14 @@ static int ipmmu_probe(struct platform_device *pdev)
 	} else {
 		/* Only IPMMU caches are affected */
 		mmu->is_mmu_tlb_disabled = ipmmu_is_mmu_tlb_disable_needed(pdev);
+
+		/*
+		 * Disable IPMMU TLB cache function of IPMMU caches
+		 * that do require such action.
+		 */
+		if (mmu->is_mmu_tlb_disabled)
+			ipmmu_write(mmu, IMSCTLR,
+					ipmmu_read(mmu, IMSCTLR) | IMSCTLR_DISCACHE);
 	}
 
 	/*


### PR DESCRIPTION
PR contains backported fixes, cleanup and suspend/resume implementation.
----------
CONFIG_RCAR_DDR_BACKUP (defined in driver for now) enables real backup/restore operations.
All messages being printed during suspend/resume are DEBUG messages.  If you don't want them to be printed just change "loglvl=all" to "loglvl=info" in Xen bootargs.