### PR TITLE
Fix coord suspend interrupt number for R-Car

### DIFF
--- a/xen/include/public/arch-arm.h
+++ b/xen/include/public/arch-arm.h
@@ -454,7 +454,7 @@ typedef uint64_t xen_callback_t;
 #define GUEST_EVTCHN_PPI        31
 
 #define GUEST_VPL011_SPI        32
-#define GUEST_COORD_SUSPEND_SPI 33
+#define GUEST_COORD_SUSPEND_SPI 129
 
 /* PSCI functions */
 #define PSCI_cpu_suspend 0


### PR DESCRIPTION
R-Car platforms cannot use SPI 33 for coordinated suspend interrupt
as it is already in use. Select unused one: SPI 97 (#129).

Fixes: dba546c08188 ("libxl: Creating device tree node for DomU guests")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>