### PR TITLE
xen/arm: Add support for GSX per-OSID irq counters

### DIFF
--- a/tools/libxl/libxl_arm.c
+++ b/tools/libxl/libxl_arm.c
@@ -102,6 +102,14 @@ int libxl__arch_domain_prepare_config(libxl__gc *gc,
         return ERROR_FAIL;
     }
 
+    if (d_config->num_vgsxs) {
+        libxl_device_vgsx *vgsx;
+
+        vgsx = &d_config->vgsxs[0];
+        config->arch.vgsx_osid = vgsx->osid;
+    } else
+        config->arch.vgsx_osid = 0;
+
     return 0;
 }
 

--- a/tools/xl/xl_parse.c
+++ b/tools/xl/xl_parse.c
@@ -1202,6 +1202,8 @@ out:
     if (rc) exit(EXIT_FAILURE);
 }
 
+#define GSX_MAX_OS_CNT	8
+
 static int parse_vgsx_config(libxl_device_vgsx *vgsx, char *token)
 {
     char *oparg;
@@ -1210,6 +1212,11 @@ static int parse_vgsx_config(libxl_device_vgsx *vgsx, char *token)
         vgsx->backend_domname = strdup(oparg);
     } else if (MATCH_OPTION("osid", token, oparg)) {
         vgsx->osid = strtoul(oparg, NULL, 0);
+        if (vgsx->osid >= GSX_MAX_OS_CNT) {
+            fprintf(stderr, "Invalid vGSX OSID parameter: %d\n", vgsx->osid);
+            return -1;
+        }
+
     } else {
         fprintf(stderr, "Unknown string \"%s\" in vgsx spec\n", token);
         return -1;

--- a/xen/arch/arm/domain.c
+++ b/xen/arch/arm/domain.c
@@ -751,6 +751,8 @@ int arch_domain_create(struct domain *d,
     if ( is_hardware_domain(d) && (rc = domain_vuart_init(d)) )
         goto fail;
 
+    d->arch.vgsx_osid = config->arch.vgsx_osid;
+
     return 0;
 
 fail:

--- a/xen/arch/arm/setup.c
+++ b/xen/arch/arm/setup.c
@@ -895,6 +895,7 @@ void __init start_xen(unsigned long boot_phys_offset,
                     "untrusted domains.\n");
 
     init_maintenance_interrupt();
+    init_gsx_interrupt();
     init_timer_interrupt();
 
     timer_init();

--- a/xen/arch/arm/vgic.c
+++ b/xen/arch/arm/vgic.c
@@ -178,7 +178,7 @@ void register_vgic_ops(struct domain *d, const struct vgic_ops *ops)
 }
 
 extern const int gsx_irq_num;
-extern void remove_gsx_guest(struct domain *d);
+extern void remove_gsx_domain(struct domain *d);
 
 void domain_vgic_free(struct domain *d)
 {
@@ -190,7 +190,7 @@ void domain_vgic_free(struct domain *d)
         struct pending_irq *p = spi_to_pending(d, i + 32);
 
         if ( p->irq == gsx_irq_num )
-            remove_gsx_guest(d);
+            remove_gsx_domain(d);
 
         if ( p->desc )
         {

--- a/xen/include/asm-arm/domain.h
+++ b/xen/include/asm-arm/domain.h
@@ -101,6 +101,9 @@ struct arch_domain
 #ifdef CONFIG_TEE
     void *tee;
 #endif
+
+    /* OSID used by virtual GSX device */
+    uint8_t vgsx_osid;
 }  __cacheline_aligned;
 
 struct arch_vcpu

--- a/xen/include/asm-arm/gic.h
+++ b/xen/include/asm-arm/gic.h
@@ -252,6 +252,7 @@ int gic_remove_irq_from_guest(struct domain *d, unsigned int virq,
 extern void gic_clear_pending_irqs(struct vcpu *v);
 
 extern void init_maintenance_interrupt(void);
+extern void init_gsx_interrupt(void);
 extern void gic_raise_guest_irq(struct vcpu *v, unsigned int irq,
         unsigned int priority);
 extern void gic_raise_inflight_irq(struct vcpu *v, unsigned int virtual_irq);

--- a/xen/include/public/arch-arm.h
+++ b/xen/include/public/arch-arm.h
@@ -318,6 +318,11 @@ struct xen_arch_domainconfig {
     /* IN */
     uint32_t nr_spis;
     /*
+     * IN
+     * OSID used by virtual GSX device.
+     */
+    uint8_t vgsx_osid;
+    /*
      * OUT
      * Based on the property clock-frequency in the DT timer node.
      * The property may be present when the bootloader/firmware doesn't


### PR DESCRIPTION
Handle GSX irq separately from other guest irqs.
Now Xen subscribes to GSX irq and performs all GSX related
actions in an extra interrupt handler. If irq status register
indicates a new event Xen reads all per-OSID irq counters and
injects GSX irqs to required domains.

Also pass vGSX OSID when creating domain.
Having matching OSID <-> DomID in place, Xen can properly recognize
to what domain to inject GSX irq.

Based on the following patches from https://github.com/xen-troops/xen/pull/139:
1. xen/arm: Add support for GSX per-OSID irq counters
   (provided by IMG)
2. xen/arm: Rewrite injecting GSX irq logic V2
3. xen/arm: Inject GSX irqs only if irq status register indicates a new event
   (provided by IMG)
4. xen/arm: Pass vGSX OSID when creating domain

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>