### PR TITLE
vpci/header: Fix missed PCI_COMMAND register write

### DIFF
--- a/xen/drivers/vpci/header.c
+++ b/xen/drivers/vpci/header.c
@@ -395,7 +395,10 @@ static int modify_bars(const struct pci_dev *pdev, uint16_t cmd, bool rom_only)
             num_mem_ranges++;
     }
 
-    defer_map(dev->domain, dev, cmd, rom_only, num_mem_ranges);
+    if ( !num_mem_ranges )
+        pci_conf_write16(pdev->sbdf, PCI_COMMAND, cmd);
+    else
+        defer_map(dev->domain, dev, cmd, rom_only, num_mem_ranges);
 
     return 0;
 


### PR DESCRIPTION
There are cases when a PCI device, root port for example, has neither
memory space nor IO. In this case PCI command register write is
missed resulting in the underlying PCI device not functional.
The root cause of the regression is that before we introduced p2m ranges
handling per BAR there was a single range set covering all the BARs
and it was created unconditionally. Then a deferred work was started
and vpci_process_pending saw that the range set is not empty and finally
got to the point where PCI_COMMAND register was written.
With per BAR handling change vpci_process_pending now rejects to process
ranges as those are all empty, thus missing final PCI_COMMAND register
write.
Fix this by checking the number of memory regions we have:
- if there are no regions write the command register directly
- if there are regions then defer work and behave as before

Fixes: f70488b8b070 ("vpci/header: Handle p2m range sets per BAR")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>