### PR TITLE
iommu/arm: Do not fail if translation for Root port's RID is absent

### DIFF
--- a/xen/drivers/passthrough/pci.c
+++ b/xen/drivers/passthrough/pci.c
@@ -1354,12 +1354,14 @@ static int iommu_add_device(struct pci_dev *pdev)
 #ifdef CONFIG_ARM
     pci_to_dev(pdev)->type = DEV_PCI;
     rc = iommu_add_pci_device(pdev->devfn, pdev);
+    if ( rc > 0 )
+        rc = 0;
 #else
     rc = hd->platform_ops->add_device(pdev->devfn, pci_to_dev(pdev));
 #endif
-    if ( rc < 0 || !pdev->phantom_stride )
+    if ( rc || !pdev->phantom_stride )
     {
-        if ( rc < 0 )
+        if ( rc )
             printk(XENLOG_WARNING "IOMMU: add %pp failed (%d)\n",
                    &pdev->sbdf, rc);
         return rc;
@@ -1372,10 +1374,12 @@ static int iommu_add_device(struct pci_dev *pdev)
             return 0;
 #ifdef CONFIG_ARM
         rc = iommu_add_pci_device(devfn, pdev);
+        if ( rc > 0 )
+            rc = 0;
 #else
         rc = hd->platform_ops->add_device(devfn, pci_to_dev(pdev));
 #endif
-        if ( rc < 0 )
+        if ( rc )
             printk(XENLOG_WARNING "IOMMU: add %pp failed (%d)\n",
                    &pdev->sbdf, rc);
     }


### PR DESCRIPTION
There might be a case when PCIe Root port doesn't issue DMA
transactions on its own, it only forwards transactions from
PCIe nodes so it's RID is not covered by "iommu-map" property.
So we shouldn't treat this *valid* case as an error condition,
but should return NO_IOMMU (device doesn't need to be protected
by an IOMMU) to the caller to decide. It won't be an issue unless
we assign the Root port to the guest (call assign_device for it).

Also update iommu_add_device() to treat the positive return
value as success condition and let the vPCI handlers to be
installed.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>