### PR TITLE
Add xenpcid daemon (server for libxl PCI) 

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -27,6 +27,7 @@ SUBDIRS-$(CONFIG_QEMU_TRAD) += qemu-xen-traditional-dir
 SUBDIRS-$(CONFIG_QEMU_XEN) += qemu-xen-dir
 endif
 
+SUBDIRS-y += xenpcid
 SUBDIRS-y += xenpmd
 SUBDIRS-$(CONFIG_GOLANG) += golang
 SUBDIRS-y += xl

--- a/tools/configure
+++ b/tools/configure
@@ -2444,7 +2444,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
-ac_config_files="$ac_config_files ../config/Tools.mk hotplug/FreeBSD/rc.d/xencommons hotplug/FreeBSD/rc.d/xendriverdomain hotplug/Linux/init.d/sysconfig.xencommons hotplug/Linux/init.d/sysconfig.xendomains hotplug/Linux/init.d/xen-watchdog hotplug/Linux/init.d/xencommons hotplug/Linux/init.d/xendomains hotplug/Linux/init.d/xendriverdomain hotplug/Linux/launch-xenstore hotplug/Linux/vif-setup hotplug/Linux/xen-hotplug-common.sh hotplug/Linux/xendomains hotplug/NetBSD/rc.d/xencommons hotplug/NetBSD/rc.d/xendriverdomain ocaml/xenstored/oxenstored.conf"
+ac_config_files="$ac_config_files ../config/Tools.mk hotplug/FreeBSD/rc.d/xencommons hotplug/FreeBSD/rc.d/xendriverdomain hotplug/Linux/init.d/sysconfig.xencommons hotplug/Linux/init.d/sysconfig.xendomains hotplug/Linux/init.d/xen-pcid hotplug/Linux/init.d/xen-watchdog hotplug/Linux/init.d/xencommons hotplug/Linux/init.d/xendomains hotplug/Linux/init.d/xendriverdomain hotplug/Linux/launch-xenstore hotplug/Linux/vif-setup hotplug/Linux/xen-hotplug-common.sh hotplug/Linux/xendomains hotplug/NetBSD/rc.d/xencommons hotplug/NetBSD/rc.d/xendriverdomain ocaml/xenstored/oxenstored.conf"
 
 ac_config_headers="$ac_config_headers config.h"
 
@@ -9983,7 +9983,7 @@ fi
 
 if test "x$systemd" = "xy"; then :
 
-    ac_config_files="$ac_config_files hotplug/Linux/systemd/proc-xen.mount hotplug/Linux/systemd/var-lib-xenstored.mount hotplug/Linux/systemd/xen-init-dom0.service hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service hotplug/Linux/systemd/xen-watchdog.service hotplug/Linux/systemd/xenconsoled.service hotplug/Linux/systemd/xendomains.service hotplug/Linux/systemd/xendriverdomain.service hotplug/Linux/systemd/xenstored.service"
+    ac_config_files="$ac_config_files hotplug/Linux/systemd/proc-xen.mount hotplug/Linux/systemd/var-lib-xenstored.mount hotplug/Linux/systemd/xen-init-dom0.service hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service hotplug/Linux/systemd/xen-pcid.service hotplug/Linux/systemd/xen-watchdog.service hotplug/Linux/systemd/xenconsoled.service hotplug/Linux/systemd/xendomains.service hotplug/Linux/systemd/xendriverdomain.service hotplug/Linux/systemd/xenstored.service"
 
 
 fi
@@ -10717,6 +10717,7 @@ do
     "hotplug/FreeBSD/rc.d/xendriverdomain") CONFIG_FILES="$CONFIG_FILES hotplug/FreeBSD/rc.d/xendriverdomain" ;;
     "hotplug/Linux/init.d/sysconfig.xencommons") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/init.d/sysconfig.xencommons" ;;
     "hotplug/Linux/init.d/sysconfig.xendomains") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/init.d/sysconfig.xendomains" ;;
+    "hotplug/Linux/init.d/xen-pcid") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/init.d/xen-pcid" ;;
     "hotplug/Linux/init.d/xen-watchdog") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/init.d/xen-watchdog" ;;
     "hotplug/Linux/init.d/xencommons") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/init.d/xencommons" ;;
     "hotplug/Linux/init.d/xendomains") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/init.d/xendomains" ;;
@@ -10733,6 +10734,7 @@ do
     "hotplug/Linux/systemd/var-lib-xenstored.mount") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/var-lib-xenstored.mount" ;;
     "hotplug/Linux/systemd/xen-init-dom0.service") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/xen-init-dom0.service" ;;
     "hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service" ;;
+    "hotplug/Linux/systemd/xen-pcid.service") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/xen-pcid.service" ;;
     "hotplug/Linux/systemd/xen-watchdog.service") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/xen-watchdog.service" ;;
     "hotplug/Linux/systemd/xenconsoled.service") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/xenconsoled.service" ;;
     "hotplug/Linux/systemd/xendomains.service") CONFIG_FILES="$CONFIG_FILES hotplug/Linux/systemd/xendomains.service" ;;

--- a/tools/helpers/Makefile
+++ b/tools/helpers/Makefile
@@ -29,12 +29,12 @@ $(INIT_XENSTORE_DOMAIN_OBJS): CFLAGS += $(CFLAGS_libxenlight)
 all: $(PROGS)
 
 xen-init-dom0: $(XEN_INIT_DOM0_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(XEN_INIT_DOM0_OBJS) $(LDLIBS_libxenctrl) $(LDLIBS_libxentoollog) $(LDLIBS_libxenstore) $(LDLIBS_libxenlight) $(APPEND_LDFLAGS)
+	$(CC) $(LDFLAGS) -o $@ $(XEN_INIT_DOM0_OBJS) $(LDLIBS_libxenctrl) $(LDLIBS_libxentoollog) $(LDLIBS_libxenstore) $(LDLIBS_libxenlight) $(LDLIBS_libxenvchan) $(APPEND_LDFLAGS)
 
 $(INIT_XENSTORE_DOMAIN_OBJS): _paths.h
 
 init-xenstore-domain: $(INIT_XENSTORE_DOMAIN_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(INIT_XENSTORE_DOMAIN_OBJS) $(LDLIBS_libxentoollog) $(LDLIBS_libxenstore) $(LDLIBS_libxenctrl) $(LDLIBS_libxenguest) $(LDLIBS_libxenlight) $(APPEND_LDFLAGS)
+	$(CC) $(LDFLAGS) -o $@ $(INIT_XENSTORE_DOMAIN_OBJS) $(LDLIBS_libxentoollog) $(LDLIBS_libxenstore) $(LDLIBS_libxenctrl) $(LDLIBS_libxenguest) $(LDLIBS_libxenlight) $(LDLIBS_libxenvchan) $(APPEND_LDFLAGS)
 
 .PHONY: install
 install: all

--- a/tools/hotplug/Linux/Makefile
+++ b/tools/hotplug/Linux/Makefile
@@ -50,11 +50,13 @@ install-initd:
 	$(INSTALL_PROG) init.d/xendomains $(DESTDIR)$(INITD_DIR)
 	$(INSTALL_PROG) init.d/xencommons $(DESTDIR)$(INITD_DIR)
 	$(INSTALL_PROG) init.d/xendriverdomain $(DESTDIR)$(INITD_DIR)
+	$(INSTALL_PROG) init.d/xen-pcid $(DESTDIR)$(INITD_DIR)
 	$(INSTALL_PROG) init.d/xen-watchdog $(DESTDIR)$(INITD_DIR)
 
 .PHONY: uninstall-initd
 uninstall-initd:
 	rm -f $(DESTDIR)$(INITD_DIR)/xen-watchdog
+	rm -f $(DESTDIR)$(INITD_DIR)/xen-pcid
 	rm -f $(DESTDIR)$(INITD_DIR)/xendriverdomain
 	rm -f $(DESTDIR)$(INITD_DIR)/xencommons
 	rm -f $(DESTDIR)$(INITD_DIR)/xendomains

--- a/tools/hotplug/Linux/init.d/xen-pcid.in
+++ b/tools/hotplug/Linux/init.d/xen-pcid.in
@@ -1,0 +1,88 @@
+#! /bin/bash
+#
+# xen-pcid
+#
+# description: Run xenpcid daemon
+### BEGIN INIT INFO
+# Provides:          xen-pcid
+# Short-Description: Start/stop xen-pcid
+# Description:       Run xenpcid daemon
+### END INIT INFO
+#
+
+. @XEN_SCRIPT_DIR@/hotplugpath.sh
+
+xencommons_config=@CONFIG_DIR@/@CONFIG_LEAF_DIR@
+
+test -f $xencommons_config/xencommons && . $xencommons_config/xencommons
+
+test -n "$XENPCID_ARGS" || XENPCID_ARGS='-f'
+DAEMON=${sbindir}/xenpcid
+base=$(basename $DAEMON)
+
+# Source function library.
+if [ -e  /etc/init.d/functions ] ; then
+    . /etc/init.d/functions
+elif [ -e /lib/lsb/init-functions ] ; then
+    . /lib/lsb/init-functions
+    success () {
+        log_success_msg $*
+    }
+    failure () {
+        log_failure_msg $*
+    }
+else
+    success () {
+        echo $*
+    }
+    failure () {
+        echo $*
+    }
+fi
+
+start() {
+	local r
+	echo -n $"Starting domain xenpcid daemon: "
+
+	$DAEMON $XENPCID_ARGS
+	r=$?
+	[ "$r" -eq 0 ] && success $"$base startup" || failure $"$base startup"
+	echo
+
+	return $r
+}
+
+stop() {
+	local r
+	echo -n $"Stopping domain xenpcid daemon: "
+
+	killall -USR1 $base 2>/dev/null
+	r=$?
+	[ "$r" -eq 0 ] && success $"$base stop" || failure $"$base stop"
+	echo
+
+	return $r
+}
+
+case "$1" in
+  start)
+  	start
+	;;
+  stop)
+	stop
+	;;
+  restart)
+	stop
+	start
+	;;
+  status)
+	;;
+  condrestart)
+	stop
+	start
+	;;
+  *)
+	echo $"Usage: $0 {start|stop|status|restart|condrestart}"
+	exit 1
+esac
+

--- a/tools/hotplug/Linux/systemd/Makefile
+++ b/tools/hotplug/Linux/systemd/Makefile
@@ -10,6 +10,7 @@ XEN_SYSTEMD_SERVICE  = xenstored.service
 XEN_SYSTEMD_SERVICE += xenconsoled.service
 XEN_SYSTEMD_SERVICE += xen-qemu-dom0-disk-backend.service
 XEN_SYSTEMD_SERVICE += xendomains.service
+XEN_SYSTEMD_SERVICE += xen-pcid.service
 XEN_SYSTEMD_SERVICE += xen-watchdog.service
 XEN_SYSTEMD_SERVICE += xen-init-dom0.service
 XEN_SYSTEMD_SERVICE += xendriverdomain.service

--- a/tools/hotplug/Linux/systemd/xen-pcid.service.in
+++ b/tools/hotplug/Linux/systemd/xen-pcid.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Xen-pcid - run xenpcid daemon
+Requires=xenstored.service
+After=xendomains.service
+ConditionPathExists=/proc/xen/capabilities
+
+[Service]
+Type=forking
+Environment="XENPCID_ARGS=-f"
+EnvironmentFile=-@CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons
+ExecStart=@sbindir@/xenpcid $XENPCID_ARGS
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -27,6 +27,7 @@
 
 #define XENPCID_MSG_EXECUTE         "execute"
 #define XENPCID_MSG_RETURN          "return"
+#define XENPCID_MSG_ERROR           "error"
 
 #define XENPCID_MSG_FIELD_ID        "id"
 #define XENPCID_MSG_FIELD_ARGS      "arguments"

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -36,6 +36,7 @@
 #define XENPCID_CMD_DIR_ID          "dir_id"
 
 #define XENPCID_CMD_WRITE           "write"
+#define XENPCID_CMD_READ_HEX        "read_hex"
 #define XENPCID_CMD_PCI_PATH        "pci_path"
 #define XENPCID_CMD_PCI_INFO        "pci_info"
 

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -1,0 +1,49 @@
+/*
+    Common definitions for Xen PCI client-server protocol.
+    Copyright (C) 2021 EPAM Systems Inc.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef XENPCID_H
+#define XENPCID_H
+
+#define XENPCID_SERVER              1
+
+#define XENPCID_XS_PATH             "/local/domain/%d/data/pcid-vchan"
+
+#define XENPCID_END_OF_MESSAGE      "\r\n"
+
+#define XENPCID_MSG_EXECUTE         "execute"
+#define XENPCID_MSG_RETURN          "return"
+
+#define XENPCID_MSG_FIELD_ID        "id"
+#define XENPCID_MSG_FIELD_ARGS      "arguments"
+
+#define XENPCID_CMD_LIST            "ls"
+#define XENPCID_CMD_DIR_ID          "dir_id"
+
+#define XENPCID_PCIBACK_DRIVER      "pciback_driver"
+
+#endif /* XENPCID_H */
+
+/*
+ * Local variables:
+ *  mode: C
+ *  c-file-style: "linux"
+ *  indent-tabs-mode: t
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ * End:
+ */

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -34,6 +34,7 @@
 
 #define XENPCID_CMD_LIST            "ls"
 #define XENPCID_CMD_UNBIND          "unbind"
+#define XENPCID_CMD_RESET           "reset"
 #define XENPCID_CMD_DIR_ID          "dir_id"
 
 #define XENPCID_CMD_WRITE           "write"

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -33,11 +33,13 @@
 #define XENPCID_MSG_FIELD_ARGS      "arguments"
 
 #define XENPCID_CMD_LIST            "ls"
+#define XENPCID_CMD_UNBIND          "unbind"
 #define XENPCID_CMD_DIR_ID          "dir_id"
 
 #define XENPCID_CMD_WRITE           "write"
 #define XENPCID_CMD_READ_HEX        "read_hex"
 #define XENPCID_CMD_EXISTS          "exists"
+#define XENPCID_CMD_READ_RESOURCES  "read_resources"
 #define XENPCID_CMD_PCI_PATH        "pci_path"
 #define XENPCID_CMD_PCI_INFO        "pci_info"
 

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -37,6 +37,7 @@
 
 #define XENPCID_CMD_WRITE           "write"
 #define XENPCID_CMD_READ_HEX        "read_hex"
+#define XENPCID_CMD_EXISTS          "exists"
 #define XENPCID_CMD_PCI_PATH        "pci_path"
 #define XENPCID_CMD_PCI_INFO        "pci_info"
 

--- a/tools/include/xenpcid.h
+++ b/tools/include/xenpcid.h
@@ -35,7 +35,14 @@
 #define XENPCID_CMD_LIST            "ls"
 #define XENPCID_CMD_DIR_ID          "dir_id"
 
+#define XENPCID_CMD_WRITE           "write"
+#define XENPCID_CMD_PCI_PATH        "pci_path"
+#define XENPCID_CMD_PCI_INFO        "pci_info"
+
 #define XENPCID_PCIBACK_DRIVER      "pciback_driver"
+#define XENPCID_PCI_DEV             "pci_dev"
+
+#define SYSFS_DRIVER_PATH           "driver_path"
 
 #endif /* XENPCID_H */
 

--- a/tools/libs/light/Makefile
+++ b/tools/libs/light/Makefile
@@ -176,7 +176,7 @@ LDUSELIBS-y += $(PTHREAD_LIBS)
 LDUSELIBS-y += -lyajl
 LDUSELIBS += $(LDUSELIBS-y)
 
-$(LIB_OBJS) $(PIC_OBJS) $(LIBXL_TEST_OBJS): CFLAGS += $(CFLAGS_LIBXL) -include $(XEN_ROOT)/tools/config.h
+$(LIB_OBJS) $(PIC_OBJS) $(LIBXL_TEST_OBJS): CFLAGS += $(CFLAGS_LIBXL) $(CFLAGS_libxenevtchn) -include $(XEN_ROOT)/tools/config.h
 $(ACPI_OBJS) $(ACPI_PIC_OBJS): CFLAGS += -I. -DLIBACPI_STDUTILS=\"$(CURDIR)/libxl_x86_acpi.h\"
 $(TEST_PROG_OBJS) _libxl.api-for-check: CFLAGS += $(CFLAGS_libxentoollog) $(CFLAGS_libxentoolcore)
 libxl_dom.o libxl_dom.opic: CFLAGS += -I$(XEN_ROOT)/tools  # include libacpi/x86.h
@@ -240,13 +240,13 @@ libxenlight_test.so: $(PIC_OBJS) $(LIBXL_TEST_OBJS)
 	$(CC) $(LDFLAGS) -Wl,$(SONAME_LDFLAG) -Wl,libxenlight.so.$(MAJOR) $(SHLIB_LDFLAGS) -o $@ $^ $(LDUSELIBS) $(APPEND_LDFLAGS)
 
 test_%: test_%.o test_common.o libxenlight_test.so
-	$(CC) $(LDFLAGS) -o $@ $^ $(filter-out %libxenlight.so, $(LDLIBS_libxenlight)) $(LDLIBS_libxentoollog) $(LDLIBS_libxentoolcore) -lyajl $(APPEND_LDFLAGS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(filter-out %libxenlight.so, $(LDLIBS_libxenlight)) $(LDLIBS_libxentoollog) $(LDLIBS_libxentoolcore) $(LDLIBS_libxenvchan) -lyajl $(APPEND_LDFLAGS)
 
 libxl-save-helper: $(SAVE_HELPER_OBJS) libxenlight.so
 	$(CC) $(LDFLAGS) -o $@ $(SAVE_HELPER_OBJS) $(LDLIBS_libxentoollog) $(LDLIBS_libxenctrl) $(LDLIBS_libxenguest) $(LDLIBS_libxentoolcore) $(APPEND_LDFLAGS)
 
 testidl: testidl.o libxenlight.so
-	$(CC) $(LDFLAGS) -o $@ testidl.o $(LDLIBS_libxenlight) $(LDLIBS_libxentoollog) $(LDLIBS_libxentoolcore) $(APPEND_LDFLAGS)
+	$(CC) $(LDFLAGS) -o $@ testidl.o $(LDLIBS_libxenlight) $(LDLIBS_libxentoollog) $(LDLIBS_libxentoolcore) $(LDLIBS_libxenvchan) $(APPEND_LDFLAGS)
 
 install: installlocal $(LIBHEADERS)
 

--- a/tools/libs/light/libxl_pci.c
+++ b/tools/libs/light/libxl_pci.c
@@ -18,12 +18,352 @@
 
 #include "libxl_internal.h"
 
+#include <libxenvchan.h>
+#include <xenpcid.h>
+
 #define PCI_BDF                "%04x:%02x:%02x.%01x"
 #define PCI_BDF_SHORT          "%02x:%02x.%01x"
 #define PCI_BDF_VDEVFN         "%04x:%02x:%02x.%01x@%02x"
 #define PCI_OPTIONS            "msitranslate=%d,power_mgmt=%d"
 #define PCI_BDF_XSPATH         "%04x-%02x-%02x-%01x"
 #define PCI_PT_QDEV_ID         "pci-pt-%02x_%02x.%01x"
+
+/*
+ *******************************************************************************
+ * xenpcid support start
+ *******************************************************************************
+ */
+struct vchan_state {
+    /* Server domain ID. */
+    libxl_domid domid;
+    /* XenStore path of the server with the ring buffer and event channel. */
+    char *xs_path;
+
+    struct libxenvchan *ctrl;
+    int select_fd;
+    /* receive buffer */
+    char *rx_buf;
+    size_t rx_buf_size; /* current allocated size */
+    size_t rx_buf_used; /* actual data in the buffer */
+};
+
+/* Returns 1 if path exists, 0 if not, ERROR_* (<0) on error. */
+static int xs_path_exists(libxl__gc *gc, const char *xs_path)
+{
+    int rc;
+    const char *dir;
+
+    rc = libxl__xs_read_checked(gc, XBT_NULL, xs_path, &dir);
+    if (rc)
+        return rc;
+    if (dir)
+        return 1;
+    return 0;
+}
+
+static libxl_domid vchan_find_pcid_server(libxl_ctx *ctx)
+{
+    GC_INIT(ctx);
+    char **domains;
+    unsigned int i, n;
+    libxl_domid domid = DOMID_INVALID;
+
+    domains = libxl__xs_directory(gc, XBT_NULL, "/local/domain", &n);
+    if (!n)
+        goto out;
+
+    for (i = 0; i < n; i++) {
+        int d;
+
+        if (sscanf(domains[i], "%d", &d) != 1)
+            continue;
+        if (xs_path_exists(gc, GCSPRINTF(XENPCID_XS_PATH, d)) > 0) {
+            /* Found the domain where the pcid server lives. */
+            domid = d;
+            break;
+        }
+    }
+
+out:
+    GC_FREE;
+    return domid;
+}
+
+static int vchan_init_client(libxl__gc *gc, struct vchan_state *state)
+{
+    state->domid = vchan_find_pcid_server(CTX);
+    if (state->domid == DOMID_INVALID) {
+        LOGE(ERROR, "Can't find vchan server");
+        return ERROR_NOTFOUND;
+    }
+
+    state->xs_path = GCSPRINTF(XENPCID_XS_PATH, state->domid);
+    state->ctrl = libxenvchan_client_init(CTX->lg, state->domid,
+                                          state->xs_path);
+    if (!state->ctrl) {
+        LOGE(ERROR, "Couldn't intialize vchan client");
+        return ERROR_FAIL;
+    }
+    state->select_fd = libxenvchan_fd_for_select(state->ctrl);
+    if (state->select_fd < 0) {
+        LOGE(ERROR, "Couldn't read file descriptor for vchan client");
+        return ERROR_FAIL;
+    }
+
+    LOG(INFO, "Intialized vchan client, server at %s", state->xs_path);
+
+    return 0;
+}
+
+/*
+ * TODO: Running this code in multi-threaded environment
+ * The code now assumes that there is only one client invocation process
+ * in one domain. In the future, it is necessary to take into account cases
+ * when within one domain there will be several requests from a client at the
+ * same time. Therefore, it will be necessary to regulate the multithreading
+ * of processes.
+ */
+static struct vchan_state *vchan_get_instance(libxl__gc *gc)
+{
+    static struct vchan_state *state = NULL;
+    int ret;
+
+    if (state)
+        return state;
+
+    state = libxl__zalloc(gc, sizeof(*state));
+    ret = vchan_init_client(gc, state);
+    if (ret)
+        state = NULL;
+
+    return state;
+}
+
+static char *vchan_prepare_cmd(libxl__gc *gc, const char *cmd,
+                               const libxl__json_object *args,
+                               int id)
+{
+    yajl_gen hand = NULL;
+    /* memory for 'buf' is owned by 'hand' */
+    const unsigned char *buf;
+    libxl_yajl_length len;
+    yajl_gen_status s;
+    char *ret = NULL;
+
+    hand = libxl_yajl_gen_alloc(NULL);
+
+    if (!hand)
+        return NULL;
+
+#if HAVE_YAJL_V2
+    /* Disable beautify for data */
+    yajl_gen_config(hand, yajl_gen_beautify, 0);
+#endif
+
+    yajl_gen_map_open(hand);
+    libxl__yajl_gen_asciiz(hand, XENPCID_MSG_EXECUTE);
+    libxl__yajl_gen_asciiz(hand, cmd);
+    libxl__yajl_gen_asciiz(hand, XENPCID_MSG_FIELD_ID);
+    yajl_gen_integer(hand, id);
+    if (args) {
+        libxl__yajl_gen_asciiz(hand, XENPCID_MSG_FIELD_ARGS);
+        libxl__json_object_to_yajl_gen(gc, hand, args);
+    }
+    yajl_gen_map_close(hand);
+
+    s = yajl_gen_get_buf(hand, &buf, &len);
+
+    if (s != yajl_gen_status_ok)
+        goto out;
+
+    ret = libxl__sprintf(gc, "%*.*s" XENPCID_END_OF_MESSAGE,
+                         (int)len, (int)len, buf);
+
+out:
+    yajl_gen_free(hand);
+    return ret;
+}
+
+/*
+ * Find a JSON object and store it in o_r.
+ * return ERROR_NOTFOUND if no object is found.
+ */
+static int vchan_get_next_msg(libxl__gc *gc, struct vchan_state *state,
+                              libxl__json_object **o_r)
+{
+    size_t len;
+    char *end = NULL;
+    const size_t eoml = sizeof(XENPCID_END_OF_MESSAGE) - 1;
+    libxl__json_object *o = NULL;
+
+    if (!state->rx_buf_used)
+        return ERROR_NOTFOUND;
+
+    /* Search for the end of a message: "\r\n" */
+    end = memmem(state->rx_buf, state->rx_buf_used, XENPCID_END_OF_MESSAGE, eoml);
+    if (!end)
+        return ERROR_NOTFOUND;
+    len = (end - state->rx_buf) + eoml;
+
+    LOGD(DEBUG, state->domid, "parsing %zuB: '%.*s'", len, (int)len,
+         state->rx_buf);
+
+    /* Replace \r by \0 so that libxl__json_parse can use strlen */
+    state->rx_buf[len - eoml] = '\0';
+    o = libxl__json_parse(gc, state->rx_buf);
+
+    if (!o) {
+        LOGD(ERROR, state->domid, "Parse error");
+        return ERROR_PROTOCOL_ERROR_PCID;
+    }
+
+    state->rx_buf_used -= len;
+    memmove(state->rx_buf, state->rx_buf + len, state->rx_buf_used);
+
+    LOGD(DEBUG, state->domid, "JSON object received: %s", JSON(o));
+
+    *o_r = o;
+
+    return 0;
+}
+
+static libxl__pcid_message_type pcid_response_type(const libxl__json_object *o)
+{
+    libxl__pcid_message_type type;
+    libxl__json_map_node *node = NULL;
+    int i;
+
+    for (i = 0; (node = libxl__json_map_node_get(o, i)); i++) {
+        if (libxl__pcid_message_type_from_string(node->map_key, &type) == 0)
+            return type;
+    }
+    return LIBXL__PCID_MESSAGE_TYPE_INVALID;
+}
+
+static int vchan_handle_message(libxl__gc *gc,
+                                struct vchan_state *state,
+                                const libxl__json_object *resp,
+                                const libxl__json_object **result)
+{
+    libxl__pcid_message_type type = pcid_response_type(resp);
+
+    *result = NULL;
+    switch (type) {
+    case LIBXL__PCID_MESSAGE_TYPE_RETURN:
+        *result = libxl__json_map_get(XENPCID_MSG_RETURN, resp, JSON_ANY);
+        return 0;
+    case LIBXL__PCID_MESSAGE_TYPE_ERROR:
+        break;
+    case LIBXL__PCID_MESSAGE_TYPE_INVALID:
+        return ERROR_PROTOCOL_ERROR_PCID;
+    default:
+        break;
+    }
+    return ERROR_INVAL;
+}
+
+#define QMP_RECEIVE_BUFFER_SIZE 4096
+#define QMP_MAX_SIZE_RX_BUF MB(1)
+
+static int vchan_read_reply(libxl__gc *gc,
+                            struct vchan_state *state,
+                            const libxl__json_object **result)
+{
+    int rc;
+    ssize_t r;
+
+    while (true) {
+        while (true) {
+            libxl__json_object *o = NULL;
+
+            /* parse rx buffer to find one json object */
+            rc = vchan_get_next_msg(gc, state, &o);
+            if (rc == ERROR_NOTFOUND)
+                break;
+            else if (rc)
+                return rc;
+
+            return vchan_handle_message(gc, state, o, result);
+        }
+
+        /* Check if the buffer still have space, or increase size */
+        if (state->rx_buf_size - state->rx_buf_used < QMP_RECEIVE_BUFFER_SIZE) {
+            size_t newsize = state->rx_buf_size * 2 + QMP_RECEIVE_BUFFER_SIZE;
+
+            if (newsize > QMP_MAX_SIZE_RX_BUF) {
+                LOGD(ERROR, state->domid,
+                     "pcid receive buffer is too big (%zu > %lld)",
+                     newsize, QMP_MAX_SIZE_RX_BUF);
+                return ERROR_BUFFERFULL;
+            }
+            state->rx_buf_size = newsize;
+            state->rx_buf = libxl__realloc(gc, state->rx_buf,
+                                           state->rx_buf_size);
+        }
+
+        while (libxenvchan_data_ready(state->ctrl)) {
+            r = libxenvchan_read(state->ctrl,
+                                 state->rx_buf + state->rx_buf_used,
+                                 state->rx_buf_size - state->rx_buf_used);
+            if (r < 0) {
+                LOGED(ERROR, state->domid, "error reading from pcid");
+                return ERROR_FAIL;
+            }
+
+            LOGE(DEBUG, "received %zdB: '%.*s'", r,
+                 (int)r, state->rx_buf + state->rx_buf_used);
+
+            state->rx_buf_used += r;
+            assert(state->rx_buf_used <= state->rx_buf_size);
+        }
+    }
+    return 0;
+}
+
+static int vchan_write(libxl__gc *gc, struct vchan_state *state, char *cmd)
+{
+    size_t len;
+    int ret;
+
+    len = strlen(cmd);
+    while (len) {
+        ret = libxenvchan_write(state->ctrl, cmd, len);
+        if (ret < 0) {
+            LOGE(ERROR, "vchan write failed");
+            return ERROR_FAIL;
+        }
+        cmd += ret;
+        len -= ret;
+    }
+    return 0;
+}
+
+static const libxl__json_object *vchan_send_command(libxl__gc *gc,
+                                                    struct vchan_state *state,
+                                                    const char *cmd,
+                                                    const libxl__json_object *args)
+{
+    const libxl__json_object *result = NULL;
+    char *json;
+    int ret;
+
+    json = vchan_prepare_cmd(gc, cmd, args, 0);
+    if (!json)
+        return NULL;
+
+    ret = vchan_write(gc, state, json);
+    if (ret < 0)
+        return NULL;
+
+    ret = vchan_read_reply(gc, state, &result);
+    return result;
+}
+
+/*
+ *******************************************************************************
+ * xenpcid support end
+ *******************************************************************************
+ */
 
 static unsigned int pci_encode_bdf(libxl_device_pci *pci)
 {
@@ -429,20 +769,36 @@ static void pci_info_xs_remove(libxl__gc *gc, libxl_device_pci *pci,
 
 libxl_device_pci *libxl_device_pci_assignable_list(libxl_ctx *ctx, int *num)
 {
+    libxl_device_pci *pcis = NULL;
+
     GC_INIT(ctx);
-    libxl_device_pci *pcis = NULL, *new;
+    *num = 0;
+
+#ifdef XENPCID_SERVER
+    struct vchan_state *vchan;
+    libxl__json_object *args = NULL;
+    const libxl__json_object *result;
+
+    vchan = vchan_get_instance(gc);
+    if (!vchan)
+        goto out;
+
+    libxl__qmp_param_add_string(gc, &args, XENPCID_CMD_DIR_ID,
+                                XENPCID_PCIBACK_DRIVER);
+    result = vchan_send_command(gc, vchan, XENPCID_CMD_LIST, args);
+
+    return 0;
+#else
+    libxl_device_pci *new;
     struct dirent *de;
     DIR *dir;
 
-    *num = 0;
-
     dir = opendir(SYSFS_PCIBACK_DRIVER);
-    if (NULL == dir) {
-        if (errno == ENOENT) {
+    if (dir == NULL) {
+        if (errno == ENOENT)
             LOG(ERROR, "Looks like pciback driver not loaded");
-        } else {
+        else
             LOGE(ERROR, "Couldn't open %s", SYSFS_PCIBACK_DRIVER);
-        }
         goto out;
     }
 
@@ -454,8 +810,10 @@ libxl_device_pci *libxl_device_pci_assignable_list(libxl_ctx *ctx, int *num)
             continue;
 
         new = realloc(pcis, ((*num) + 1) * sizeof(*new));
-        if (NULL == new)
-            continue;
+        if (new == NULL) {
+            LOGE(ERROR, "Couldn't realloc pcis struct for new entry");
+            break;
+        }
 
         pcis = new;
         new = pcis + *num;
@@ -473,6 +831,7 @@ libxl_device_pci *libxl_device_pci_assignable_list(libxl_ctx *ctx, int *num)
     }
 
     closedir(dir);
+#endif /* XENPCID_SERVER */
 out:
     GC_FREE;
     return pcis;

--- a/tools/libs/light/libxl_pci.c
+++ b/tools/libs/light/libxl_pci.c
@@ -1611,16 +1611,6 @@ void libxl__device_pci_add(libxl__egc *egc, uint32_t domid,
     pas->starting = starting;
     pas->callback = device_pci_add_stubdom_done;
 
-/* FIXME: CONFIG_ARM is not defined for this project. */
-/*#ifdef CONFIG_ARM*/
-    rc = xc_assign_device(ctx->xch, domid, pci_encode_bdf(pci), /*flags*/0);
-    if (rc < 0) {
-        LOGED(ERROR, domid, "xc_assign_device failed");
-        rc = ERROR_FAIL;
-    }
-    goto out;
-/*#endif*/
-
     if (libxl__domain_type(gc, domid) == LIBXL_DOMAIN_TYPE_HVM) {
         rc = xc_test_assign_device(ctx->xch, domid, pci_encode_bdf(pci));
         if (rc) {

--- a/tools/libs/light/libxl_types.idl
+++ b/tools/libs/light/libxl_types.idl
@@ -76,6 +76,7 @@ libxl_error = Enumeration("error", [
     (-30, "QMP_DEVICE_NOT_ACTIVE"), # a device has failed to be become active
     (-31, "QMP_DEVICE_NOT_FOUND"), # the requested device has not been found
     (-32, "QEMU_API"), # QEMU's replies don't contains expected members
+    (-33, "PROTOCOL_ERROR_PCID"),
     ], value_namespace = "")
 
 libxl_domain_type = Enumeration("domain_type", [

--- a/tools/libs/light/libxl_types_internal.idl
+++ b/tools/libs/light/libxl_types_internal.idl
@@ -57,3 +57,9 @@ libxl__device_action = Enumeration("device_action", [
     (1, "ADD"),
     (2, "REMOVE"),
     ])
+
+libxl__pcid_message_type = Enumeration("pcid_message_type", [
+    (1, "return"),
+    (2, "error"),
+    (3, "invalid"),
+    ])

--- a/tools/xenpcid/Makefile
+++ b/tools/xenpcid/Makefile
@@ -1,0 +1,32 @@
+XEN_ROOT=$(CURDIR)/../..
+include $(XEN_ROOT)/tools/Rules.mk
+
+CFLAGS += -Werror
+CFLAGS += $(CFLAGS_libxenstore) $(CFLAGS_libxenvchan) $(CFLAGS_libxenlight)
+CFLAGS += -include $(XEN_ROOT)/tools/config.h # libxl_json.h needs it.
+
+LDLIBS += $(LDLIBS_libxenstore) $(LDLIBS_libxenvchan) $(LDLIBS_libxl_json) $(LDLIBS_libxl)
+
+.PHONY: all
+all: xenpcid
+
+.PHONY: install
+install: all
+	$(INSTALL_DIR) $(DESTDIR)$(sbindir)
+	$(INSTALL_PROG) xenpcid $(DESTDIR)$(sbindir)
+
+.PHONY: clean
+clean:
+	$(RM) -f xenpcid xenpcid.o $(DEPS_RM)
+
+.PHONY: distclean
+distclean: clean
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(sbindir)/xenpcid
+
+xenpcid: xenpcid.o Makefile
+	$(CC) $(LDFLAGS) $< -o $@ $(LDLIBS) -lyajl $(APPEND_LDFLAGS)
+
+-include $(DEPS_INCLUDE)

--- a/tools/xenpcid/pcid.h
+++ b/tools/xenpcid/pcid.h
@@ -50,6 +50,11 @@ enum pcid__json_node_type {
     JSON_ANY     = 255 /* this is a mask of all values above, adjust as needed */
 };
 
+struct list_head {
+    struct list_head *next, *prev;
+    char *val;
+};
+
 struct flexarray {
     int size;
     int autogrow;

--- a/tools/xenpcid/pcid.h
+++ b/tools/xenpcid/pcid.h
@@ -20,6 +20,7 @@
 #define PCID_H
 /* TODO: Determine id of control domain and use it all over the code */
 #define DOM0_ID 0
+#define FOREGROUND_OPT "-f"
 
 #if defined(__linux__)
 #define SYSFS_PCIBACK_DRIVER   "/sys/bus/pci/drivers/pciback"

--- a/tools/xenpcid/pcid.h
+++ b/tools/xenpcid/pcid.h
@@ -1,0 +1,102 @@
+/*
+    Definitions for Xen PCI server protocol.
+    Copyright (C) 2021 EPAM Systems Inc.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PCID_H
+#define PCID_H
+/* TODO: Determine id of control domain and use it all over the code */
+#define DOM0_ID 0
+
+#if defined(__linux__)
+#define SYSFS_PCIBACK_DRIVER   "/sys/bus/pci/drivers/pciback"
+#endif
+
+#define PCI_INFO_PATH "/libxl/pci"
+#define PCI_BDF_XSPATH         "%04x-%02x-%02x-%01x"
+#define PCI_BDF                "%04x:%02x:%02x.%01x"
+
+/*
+ * TODO: Avoid code duplicates
+ *
+ * The presentation of the structures and some of the functions were taken from
+ * Libxl internal files. It will be necessary to made this code common to avoid
+ * duplicates.
+ */
+
+enum pcid__json_node_type {
+    JSON_NULL    = (1 << 0),
+    JSON_BOOL    = (1 << 1),
+    JSON_INTEGER = (1 << 2),
+    JSON_DOUBLE  = (1 << 3),
+    JSON_LIST    = (1 << 4),
+    JSON_STRING  = (1 << 5),
+    JSON_MAP     = (1 << 6),
+    JSON_ARRAY   = (1 << 7),
+    JSON_ANY     = 255 /* this is a mask of all values above, adjust as needed */
+};
+
+struct flexarray {
+    int size;
+    int autogrow;
+    unsigned int count;
+    void **data; /* array of pointer */
+    libxl_ctx *ctx;
+};
+
+struct pcid__json_map_node {
+    char *map_key;
+    struct pcid__json_object *obj;
+};
+
+struct pcid__json_object {
+    enum pcid__json_node_type type;
+    union {
+        bool b;
+        long long i;
+        double d;
+        char *string;
+        struct list_head *list;
+        /* List of pcid__json_object */
+        struct flexarray *array;
+        /* List of pcid__json_map_node */
+        struct flexarray *map;
+    } u;
+    struct pcid__json_object *parent;
+};
+
+struct pcid__yajl_ctx {
+    libxl_ctx *ctx;
+    yajl_handle hand;
+    struct pcid__json_object *head;
+    struct pcid__json_object *current;
+};
+
+struct vchan_state {
+    /* Server domain ID. */
+    libxl_domid domid;
+    /* XenStore path of the server with the ring buffer and event channel. */
+    char *xs_path;
+
+    struct libxenvchan *ctrl;
+    int select_fd;
+    /* receive buffer */
+    char *rx_buf;
+    size_t rx_buf_size; /* current allocated size */
+    size_t rx_buf_used; /* actual data in the buffer */
+};
+
+#endif /* PCID_H */

--- a/tools/xenpcid/pcid.h
+++ b/tools/xenpcid/pcid.h
@@ -18,6 +18,9 @@
 
 #ifndef PCID_H
 #define PCID_H
+
+#include <unistd.h>
+
 /* TODO: Determine id of control domain and use it all over the code */
 #define DOM0_ID 0
 #define FOREGROUND_OPT "-f"
@@ -39,6 +42,8 @@
  * duplicates.
  */
 
+#define PROC_PCI_NUM_RESOURCES 7
+
 enum pcid__json_node_type {
     JSON_NULL    = (1 << 0),
     JSON_BOOL    = (1 << 1),
@@ -54,6 +59,13 @@ enum pcid__json_node_type {
 struct list_head {
     struct list_head *next, *prev;
     char *val;
+};
+
+struct list_resources {
+    struct list_resources *next, *prev;
+    long long start;
+    long long end;
+    long long flags;
 };
 
 struct flexarray {
@@ -77,6 +89,7 @@ struct pcid__json_object {
         double d;
         char *string;
         struct list_head *list;
+        struct list_resources *list_rsc;
         /* List of pcid__json_object */
         struct flexarray *array;
         /* List of pcid__json_map_node */

--- a/tools/xenpcid/pcid.h
+++ b/tools/xenpcid/pcid.h
@@ -24,6 +24,7 @@
 
 #if defined(__linux__)
 #define SYSFS_PCIBACK_DRIVER   "/sys/bus/pci/drivers/pciback"
+#define SYSFS_PCI_DEV          "/sys/bus/pci/devices"
 #endif
 
 #define PCI_INFO_PATH "/libxl/pci"

--- a/tools/xenpcid/xenpcid.c
+++ b/tools/xenpcid/xenpcid.c
@@ -35,6 +35,10 @@
 #include <dirent.h>
 #include "pcid.h"
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* #define RUN_STANDALONE */
 #define BUFSIZE 4096
 /*
  * TODO: Running this code in multi-threaded environment
@@ -588,6 +592,31 @@ static void vchan_receive_command(struct vchan_state *state)
     free(reply);
 }
 
+/* Borrowed daemonize from xenstored - Initially written by Stevens. */
+static void daemonize(void)
+{
+    pid_t pid;
+
+    if ( (pid = fork()) < 0 )
+        exit(1);
+
+    if ( pid != 0 )
+        exit(0);
+
+    setsid();
+
+    if ( (pid = fork()) < 0 )
+        exit(1);
+
+    if ( pid != 0 )
+        exit(0);
+
+    if ( chdir("/") == -1 )
+        exit(1);
+
+    umask(0);
+}
+
 int main(int argc, char *argv[])
 {
     int ret, rsiz, wsiz;
@@ -596,6 +625,9 @@ int main(int argc, char *argv[])
     char *domid_str, vchan_path[100];
     struct xs_handle *xs;
     struct vchan_state *vchan;
+
+    if (argc == 2 && strcmp(argv[1], FOREGROUND_OPT) == 0)
+        daemonize();
 
     xs = xs_open(0);
     if (!xs)

--- a/tools/xenpcid/xenpcid.c
+++ b/tools/xenpcid/xenpcid.c
@@ -1,0 +1,686 @@
+/*
+    Xenpcid daemon that acts as a server for the client in the libxl PCI
+
+    Copyright (C) 2021 EPAM Systems Inc.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE  // required for strchrnul()
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <libxenvchan.h>
+#include <xenpcid.h>
+#include <xenstore.h>
+
+#include <libxl.h>
+#include <libxl_json.h>
+#include <dirent.h>
+#include "pcid.h"
+
+#define BUFSIZE 4096
+/*
+ * TODO: Running this code in multi-threaded environment
+ * Now the code is designed so that only one request to the server
+ * from the client is made in one domain. In the future, it is necessary
+ * to take into account cases when from different domains there can be
+ * several requests from a client at the same time. Therefore, it will be
+ * necessary to regulate the multithreading of processes for global variables.
+ */
+char inbuf[BUFSIZE];
+char outbuf[BUFSIZE];
+int insiz = 0;
+int outsiz = 0;
+struct libxenvchan *ctrl;
+
+static void *pcid_zalloc(size_t size)
+{
+    void *ptr = calloc(size, 1);
+
+    if (!ptr) {
+        fprintf(stderr, "Memory allocation failed\n");
+        exit(1);
+    }
+
+    return ptr;
+}
+
+static void free_pcid_obj_map(struct pcid__json_object *obj)
+{
+    if (obj->u.map)
+    {
+        unsigned int count;
+        struct flexarray *map;
+
+        map = obj->u.map;
+        count = map->count;
+        while (count--) {
+            struct pcid__json_map_node *node;
+
+            node = map->data[count];
+            free(node->map_key);
+            free(node->obj);
+            free(node);
+        }
+        free(map);
+    }
+}
+
+static void vchan_wr(char *msg)
+{
+    int ret, len;
+
+    len = strlen(msg);
+    while (len) {
+        ret = libxenvchan_write(ctrl, msg, len);
+        if (ret < 0) {
+            fprintf(stderr, "vchan write failed\n");
+            return ;
+        }
+        msg += ret;
+        len -= ret;
+    }
+}
+
+static int set_nonblocking(int fd, int nonblocking)
+{
+    int flags = fcntl(fd, F_GETFL);
+    if (flags == -1)
+        return -1;
+
+    if (nonblocking)
+        flags |= O_NONBLOCK;
+    else
+        flags &= ~O_NONBLOCK;
+
+    if (fcntl(fd, F_SETFL, flags) == -1)
+        return -1;
+
+    return 0;
+}
+
+static yajl_gen_status pcid__yajl_gen_asciiz(yajl_gen hand, const char *str)
+{
+    return yajl_gen_string(hand, (const unsigned char *)str, strlen(str));
+}
+
+static char *vchan_prepare_cmd(struct pcid__json_object *result,
+                               int id)
+{
+    yajl_gen hand = NULL;
+    /* memory for 'buf' is owned by 'hand' */
+    const unsigned char *buf;
+    libxl_yajl_length len;
+    yajl_gen_status s;
+    char *ret = NULL;
+
+    hand = libxl_yajl_gen_alloc(NULL);
+    if (!hand) {
+        fprintf(stderr, "Error with hand allocation\n");
+        return NULL;
+    }
+
+#if HAVE_YAJL_V2
+    /* Disable beautify for data */
+    yajl_gen_config(hand, yajl_gen_beautify, 0);
+#endif
+
+    yajl_gen_map_open(hand);
+    if ( !result )
+        pcid__yajl_gen_asciiz(hand, XENPCID_MSG_ERROR);
+    else
+        pcid__yajl_gen_asciiz(hand, XENPCID_MSG_RETURN);
+    yajl_gen_array_open(hand);
+    yajl_gen_array_close(hand);
+    pcid__yajl_gen_asciiz(hand, XENPCID_MSG_FIELD_ID);
+    yajl_gen_integer(hand, id);
+    yajl_gen_map_close(hand);
+
+    s = yajl_gen_get_buf(hand, &buf, &len);
+    if (s != yajl_gen_status_ok) {
+        goto out;
+    }
+
+    ret = pcid_zalloc((int)len + strlen(XENPCID_END_OF_MESSAGE));
+    sprintf(ret, "%*.*s" XENPCID_END_OF_MESSAGE,
+            (int)len, (int)len, buf);
+
+    yajl_gen_free(hand);
+out:
+    return ret;
+}
+
+static int flexarray_grow(struct flexarray *array, int extents)
+{
+    int newsize;
+    void *newptr;
+
+    newsize = array->size + extents;
+    newptr = realloc(array->data, newsize);
+    if (newptr)
+       array->data = newptr;
+    else {
+        fprintf(stderr, "Memory reallocation for data in array failed\n");
+        return 1;
+    }
+    array->size += extents;
+
+    return 0;
+}
+
+static int flexarray_set(struct flexarray *array, unsigned int idx, void *ptr)
+{
+    if (idx >= array->size) {
+        int newsize;
+
+        if (!array->autogrow)
+            return 1;
+        newsize = (array->size * 2 < idx) ? idx + 1 : array->size * 2;
+        if (flexarray_grow(array, newsize - array->size))
+            return 1;
+    }
+    if (idx + 1 > array->count)
+        array->count = idx + 1;
+    array->data[idx] = ptr;
+
+    return 0;
+}
+
+static int flexarray_append(struct flexarray *array, void *ptr)
+{
+    return flexarray_set(array, array->count, ptr);
+}
+
+static struct flexarray *flexarray_make(int size, int autogrow)
+{
+    struct flexarray *array;
+
+    array = pcid_zalloc(sizeof(*array));
+    array->size = size;
+    array->autogrow = autogrow;
+    array->count = 0;
+    array->data = calloc(size, sizeof(*(array->data)));
+
+    return array;
+}
+
+static int flexarray_get(struct flexarray *array, int idx, void **ptr)
+{
+    if (idx >= array->size)
+        return 1;
+    *ptr = array->data[idx];
+    return 0;
+}
+
+static inline bool pcid__json_object_is_map(const struct pcid__json_object *o)
+{
+    return o != NULL && o->type == JSON_MAP;
+}
+
+static struct pcid__json_object *pcid__json_map_get(const char *key,
+                                                    const struct pcid__json_object *o,
+                                                    enum pcid__json_node_type expected_type)
+{
+    struct flexarray *maps = NULL;
+    int idx = 0;
+    struct pcid__json_map_node *node = NULL;
+
+    if (pcid__json_object_is_map(o)) {
+        maps = o->u.map;
+        for (idx = 0; idx < maps->count; idx++) {
+            if (flexarray_get(maps, idx, (void**)&node) != 0) {
+                return NULL;
+            }
+
+            if (strcmp(key, node->map_key) == 0) {
+                if (expected_type == JSON_ANY
+                    || (node->obj && (node->obj->type & expected_type))) {
+                    return node->obj;
+                } else
+                    return NULL;
+            }
+        }
+    }
+    return NULL;
+}
+
+static inline bool pcid__json_object_is_array(const struct pcid__json_object *o)
+{
+    return o != NULL && o->type == JSON_ARRAY;
+}
+
+static int pcid__json_object_append_to(struct pcid__json_object *obj,
+                                       struct pcid__yajl_ctx *ctx_yajl)
+{
+    struct pcid__json_object *dst = ctx_yajl->current;
+
+    if (dst) {
+        switch (dst->type) {
+        case JSON_MAP: {
+            struct pcid__json_map_node *last = NULL;
+
+            if (dst->u.map->count == 0) {
+                fprintf(stderr,
+                        "Try to add a value to an empty map (with no key)\n");
+                return ERROR_FAIL;
+            }
+            flexarray_get(dst->u.map, dst->u.map->count - 1, (void**)&last);
+            last->obj = obj;
+            break;
+        }
+        case JSON_ARRAY:
+            flexarray_append(dst->u.array, obj);
+            break;
+        default:
+            fprintf(stderr,
+                    "Try append an object is not a map/array (%i)\n",
+                    dst->type);
+            return ERROR_FAIL;
+        }
+    }
+
+    obj->parent = dst;
+
+    if (pcid__json_object_is_map(obj) || pcid__json_object_is_array(obj))
+        ctx_yajl->current = obj;
+    if (ctx_yajl->head == NULL)
+        ctx_yajl->head = obj;
+
+    return 0;
+}
+
+static int json_callback_string(void *opaque, const unsigned char *str,
+                                long unsigned int len)
+{
+    struct pcid__yajl_ctx *ctx = opaque;
+    char *t = NULL;
+    struct pcid__json_object *obj = NULL;
+
+    t = pcid_zalloc(len + 1);
+    strncpy(t, (const char *) str, len);
+    t[len] = 0;
+
+    obj = pcid_zalloc(sizeof(*obj));
+    obj->u.string = t;
+
+    if (pcid__json_object_append_to(obj, ctx))
+        return 0;
+
+    return 1;
+}
+
+static struct pcid__json_object *pcid__json_object_alloc(enum pcid__json_node_type type)
+{
+    struct pcid__json_object *obj;
+
+    obj = pcid_zalloc(sizeof(*obj));
+    obj->type = type;
+    obj->u.map = NULL;
+    obj->u.array = NULL;
+    obj->u.string = NULL;
+
+    if (type == JSON_MAP || type == JSON_ARRAY) {
+        struct flexarray *array = flexarray_make(1, 1);
+
+        if (type == JSON_MAP)
+            obj->u.map = array;
+        else
+            obj->u.array = array;
+    }
+
+    return obj;
+}
+
+static int json_callback_map_key(void *opaque, const unsigned char *str,
+                                 libxl_yajl_length len)
+{
+    struct pcid__yajl_ctx *ctx_yajl = opaque;
+    char *t = NULL;
+    struct pcid__json_object *obj = ctx_yajl->current;
+
+    t = pcid_zalloc(len + 1);
+
+    strncpy(t, (const char *) str, len);
+    t[len] = 0;
+
+    if (pcid__json_object_is_map(obj)) {
+        struct pcid__json_map_node *node;
+
+        node = pcid_zalloc(sizeof(*node));
+        node->map_key = t;
+        node->obj = NULL;
+
+        flexarray_append(obj->u.map, node);
+    } else {
+        fprintf(stderr, "Current json object is not a map\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+static int json_callback_start_map(void *opaque)
+{
+    struct pcid__yajl_ctx *ctx = opaque;
+    struct pcid__json_object *obj = NULL;
+
+    obj = pcid__json_object_alloc(JSON_MAP);
+
+    if (pcid__json_object_append_to(obj, ctx))
+        return 0;
+
+    return 1;
+}
+
+static int json_callback_end_map(void *opaque)
+{
+    struct pcid__yajl_ctx *ctx = opaque;
+
+    if (ctx->current) {
+        ctx->current = ctx->current->parent;
+    } else {
+        fprintf(stderr,
+                "No current pcid__json_object, cannot use his parent\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+static yajl_callbacks callbacks = {
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    json_callback_string,
+    json_callback_start_map,
+    json_callback_map_key,
+    json_callback_end_map,
+    NULL,
+    NULL,
+};
+
+static void yajl_ctx_free(struct pcid__yajl_ctx *yajl_ctx)
+{
+    if (yajl_ctx->hand) {
+        yajl_free(yajl_ctx->hand);
+        yajl_ctx->hand = NULL;
+    }
+}
+
+static struct pcid__json_object *pcid__json_parse(const char *s)
+{
+    yajl_status status;
+    struct pcid__yajl_ctx yajl_ctx;
+    struct pcid__json_object *o = NULL;
+    unsigned char *str = NULL;
+
+    memset(&yajl_ctx, 0, sizeof (yajl_ctx));
+    yajl_ctx.hand = libxl__yajl_alloc(&callbacks, NULL, &yajl_ctx);
+
+    status = yajl_parse(yajl_ctx.hand, (const unsigned char *)s, strlen(s));
+    if (status != yajl_status_ok) {
+        str = yajl_get_error(yajl_ctx.hand, 1, (const unsigned char*)s, strlen(s));
+        fprintf(stderr, "yajl_parse error: %s\n", str);
+        yajl_free_error(yajl_ctx.hand, str);
+        goto out;
+    }
+
+    status = yajl_complete_parse(yajl_ctx.hand);
+    if (status != yajl_status_ok) {
+        str = yajl_get_error(yajl_ctx.hand, 1, (const unsigned char*)s, strlen(s));
+        fprintf(stderr, "yajl_complete_parse error: %s\n", str);
+        yajl_free_error(yajl_ctx.hand, str);
+        goto out;
+    }
+
+    o = yajl_ctx.head;
+
+    yajl_ctx.head = NULL;
+
+    yajl_ctx_free(&yajl_ctx);
+    return o;
+
+out:
+    str = yajl_get_error(yajl_ctx.hand, 1, (const unsigned char*)s, strlen(s));
+    fprintf(stderr, "yajl error: %s\n", str);
+    yajl_free_error(yajl_ctx.hand, str);
+    yajl_ctx_free(&yajl_ctx);
+    return NULL;
+}
+
+/*
+ * Find a JSON object and store it in o_r.
+ * return ERROR_NOTFOUND if no object is found.
+ */
+static int vchan_get_next_msg(struct vchan_state *state,
+                              struct pcid__json_object **o_r)
+{
+    size_t len;
+    char *end = NULL;
+    const char eom[] = XENPCID_END_OF_MESSAGE;
+    const size_t eoml = sizeof(eom) - 1;
+    struct pcid__json_object *o = NULL;
+
+    if (!state->rx_buf_used) {
+        fprintf(stderr, "Buffer is empty\n");
+        return ERROR_NOTFOUND;
+    }
+
+    /* Search for the end of a message: "\r\n" */
+    end = memmem(state->rx_buf, state->rx_buf_size, eom, eoml);
+    if (!end) {
+        fprintf(stderr, "End of the message not found\n");
+        return ERROR_NOTFOUND;
+    }
+    len = (end - state->rx_buf) + eoml;
+
+    fprintf(stderr, "parsing %luB: '%.*s'\n", len, (int)len,
+         state->rx_buf);
+
+    /* Replace \r by \0 so that pcid__json_parse can use strlen */
+    state->rx_buf[len - eoml] = '\0';
+    o = pcid__json_parse(state->rx_buf);
+
+    if (!o) {
+        fprintf(stderr, "Parse error\n");
+        return ERROR_PROTOCOL_ERROR_PCID;
+    }
+
+    *o_r = o;
+
+    outsiz -= len;
+    if (outsiz) {
+        memmove(outbuf, outbuf + len, outsiz);
+        insiz += len;
+    } else
+        memset(outbuf, 0, BUFSIZE);
+
+    return 0;
+}
+
+static int vchan_handle_message(struct vchan_state *state,
+                                struct pcid__json_object *resp,
+                                struct pcid__json_object **result)
+{
+    struct pcid__json_object *command_obj;
+    char *command_name;
+
+    command_obj = pcid__json_map_get(XENPCID_MSG_EXECUTE, resp, JSON_ANY);
+    command_name = command_obj->u.string;
+
+    free(command_name);
+
+    return 0;
+}
+
+static int vchan_process_message(struct vchan_state *state,
+                                 struct pcid__json_object **result)
+{
+    int rc;
+    struct pcid__json_object *o = NULL, *reply = NULL;
+
+    /* parse rx buffer to find one json object */
+    rc = vchan_get_next_msg(state, &o);
+    if (rc == ERROR_NOTFOUND) {
+        perror("Message not found\n");
+        return rc;
+    }
+
+    rc = vchan_handle_message(state, o, &reply);
+    free_pcid_obj_map(o);
+    free(o);
+
+    if (rc == 0)
+        *result = reply;
+
+    return 0;
+}
+
+static struct vchan_state *vchan_get_instance(void)
+{
+    static struct vchan_state *state = NULL;
+
+    if (state)
+        return state;
+
+    state = pcid_zalloc(sizeof(*state));
+
+    return state;
+}
+
+static void vchan_receive_command(struct vchan_state *state)
+{
+    struct pcid__json_object *result = NULL;
+    char *reply;
+    int ret;
+
+    state->rx_buf = outbuf;
+    state->rx_buf_size = outsiz;
+    state->rx_buf_used = outsiz;
+    ret = vchan_process_message(state, &result);
+
+    reply = vchan_prepare_cmd(result, 0);
+    if (!reply) {
+        fprintf(stderr, "Reply preparing failed\n");
+        return;
+    }
+
+    vchan_wr(reply);
+    free(reply);
+}
+
+int main(int argc, char *argv[])
+{
+    int ret, rsiz, wsiz;
+    int libxenvchan_fd;
+    uint32_t domid;
+    char *domid_str, vchan_path[100];
+    struct xs_handle *xs;
+    struct vchan_state *vchan;
+
+    xs = xs_open(0);
+    if (!xs)
+        perror("XS opening ERROR");;
+
+    domid_str = xs_read(xs, XBT_NULL, "domid", NULL);
+    domid = atoi(domid_str);
+    free(domid_str);
+    free(xs);
+
+    rsiz = 0;
+    wsiz = 0;
+    sprintf(vchan_path, XENPCID_XS_PATH, domid);
+    ctrl = libxenvchan_server_init(NULL, DOM0_ID, vchan_path, rsiz, wsiz);
+    if (!ctrl) {
+        perror("Libxenvchan server init failed\n");
+        exit(1);
+    }
+
+    vchan = vchan_get_instance();
+    if (!vchan)
+        perror("Vchan creation failed\n");
+
+    vchan->domid = DOM0_ID;
+    vchan->xs_path = vchan_path;
+    vchan->ctrl = ctrl;
+
+    libxenvchan_fd = libxenvchan_fd_for_select(ctrl);
+    vchan->select_fd = libxenvchan_fd;
+
+    for (;;) {
+        fd_set rfds;
+        fd_set wfds;
+        FD_ZERO(&rfds);
+        FD_ZERO(&wfds);
+        if (insiz != BUFSIZE)
+            FD_SET(0, &rfds);
+        if (outsiz)
+            FD_SET(1, &wfds);
+        FD_SET(libxenvchan_fd, &rfds);
+        ret = select(libxenvchan_fd + 1, &rfds, &wfds, NULL, NULL);
+        if (ret < 0) {
+            fprintf(stderr, "Error occured during the libxenvchan fd monitoring\n");
+            goto exit;
+        }
+        if (FD_ISSET(0, &rfds)) {
+            ret = read(0, inbuf + insiz, BUFSIZE - insiz);
+            if (ret < 0 && errno != EAGAIN)
+                goto exit;
+            if (ret == 0) {
+                while (insiz) {
+                    libxenvchan_wait(ctrl);
+                }
+                goto out;
+            }
+            if (ret)
+                insiz += ret;
+        }
+        if (FD_ISSET(libxenvchan_fd, &rfds))
+            libxenvchan_wait(ctrl);
+        if (FD_ISSET(1, &wfds))
+            vchan_receive_command(vchan);
+        while (libxenvchan_data_ready(ctrl) && outsiz < BUFSIZE) {
+            ret = libxenvchan_read(ctrl, outbuf + outsiz, BUFSIZE - outsiz);
+            if (ret < 0)
+                goto exit;
+            outsiz += ret;
+            vchan_receive_command(vchan);
+            while (!libxenvchan_data_ready(ctrl))
+                libxenvchan_wait(ctrl);
+        }
+        if (!libxenvchan_is_open(ctrl)) {
+            if (set_nonblocking(1, 0))
+                goto exit;
+            while (outsiz)
+                vchan_receive_command(vchan);
+            goto out;
+        }
+    }
+
+out:
+    free(vchan);
+    return 0;
+
+exit:
+    free(vchan);
+    exit(1);
+}

--- a/tools/xenpcid/xenpcid.c
+++ b/tools/xenpcid/xenpcid.c
@@ -509,6 +509,49 @@ fail:
     return -1;
 }
 
+static int handle_reset_cmd(char *pci_path, char *pci_info)
+{
+    char *reset;
+    int rc, fd;
+
+    reset = (char *)pcid_zalloc(strlen(SYSFS_PCIBACK_DRIVER) + strlen(pci_path) + 1);
+    sprintf(reset, SYSFS_PCIBACK_DRIVER"%s", pci_path);
+
+    fd = open(reset, O_WRONLY);
+    if (fd >= 0) {
+        rc = write(fd, pci_info, strlen(pci_info));
+        if (rc < 0)
+            fprintf(stderr, "write to %s returned %d\n", reset, rc);
+        close(fd);
+        free(reset);
+        return rc < 0 ? rc : 0;
+    }
+    if (errno != ENOENT)
+        fprintf(stderr, "Failed to access pciback path %s\n", reset);
+    free(reset);
+    reset = (char *)pcid_zalloc(strlen(SYSFS_PCI_DEV) + strlen(pci_info) +
+                                strlen("//reset") + 1);
+    sprintf(reset, "%s/%s/reset", SYSFS_PCI_DEV, pci_info);
+    fd = open(reset, O_WRONLY);
+    if (fd >= 0) {
+        rc = write(fd, "1", 1);
+        if (rc < 0)
+            fprintf(stderr, "write to %s returned %d\n", reset, rc);
+        close(fd);
+        free(reset);
+        return rc < 0 ? rc : 0;
+    }
+    if (errno == ENOENT) {
+        fprintf(stderr,
+                "The kernel doesn't support reset from sysfs for PCI device %s\n",
+                pci_info);
+    } else {
+        fprintf(stderr, "Failed to access reset path %s\n", reset);
+    }
+    free(reset);
+    return -1;
+}
+
 static inline bool pcid__json_object_is_array(const struct pcid__json_object *o)
 {
     return o != NULL && o->type == JSON_ARRAY;
@@ -986,6 +1029,34 @@ out:
     return result;
 }
 
+static struct pcid__json_object *process_reset_cmd(struct pcid__json_object *resp)
+{
+    struct pcid__json_object *result = NULL, *args, *pci_path, *pci_info;
+    int ret;
+
+    args = pcid__json_map_get(XENPCID_MSG_FIELD_ARGS, resp, JSON_MAP);
+    if (!args)
+        goto out;
+    pci_info = pcid__json_map_get(XENPCID_CMD_PCI_INFO, args, JSON_ANY);
+    if (!pci_info)
+        goto free_args;
+    pci_path = pcid__json_map_get(XENPCID_CMD_PCI_PATH, args, JSON_ANY);
+
+    ret = handle_reset_cmd(pci_path->u.string, pci_info->u.string);
+    free(pci_path->u.string);
+    if (ret < 0)
+        goto free_pci_info;
+
+    result = pcid__json_object_alloc(JSON_STRING);
+
+free_pci_info:
+    free(pci_info->u.string);
+free_args:
+    free_pcid_obj_map(args);
+out:
+    return result;
+}
+
 static int vchan_handle_message(struct vchan_state *state,
                                 struct pcid__json_object *resp,
                                 struct pcid__json_object **result)
@@ -1008,6 +1079,8 @@ static int vchan_handle_message(struct vchan_state *state,
         (*result) = process_read_rsc_cmd(resp);
     else if (strcmp(command_name, XENPCID_CMD_UNBIND) == 0)
         (*result) = process_unbind_cmd(resp);
+    else if (strcmp(command_name, XENPCID_CMD_RESET) == 0)
+        (*result) = process_reset_cmd(resp);
     else
         fprintf(stderr, "Unknown command\n");
     free(command_name);

--- a/tools/xl/Makefile
+++ b/tools/xl/Makefile
@@ -15,6 +15,7 @@ LDFLAGS += $(PTHREAD_LDFLAGS)
 CFLAGS_XL += $(CFLAGS_libxenlight)
 CFLAGS_XL += $(CFLAGS_libxenutil)
 CFLAGS_XL += -Wshadow
+CFLAGS_XL += $(CFLAGS_libxenvchan)
 
 XL_OBJS-$(CONFIG_X86) = xl_psr.o
 XL_OBJS = xl.o xl_cmdtable.o xl_sxp.o xl_utils.o $(XL_OBJS-y)
@@ -38,7 +39,7 @@ $(XL_OBJS): _paths.h
 all: xl
 
 xl: $(XL_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(XL_OBJS) $(LDLIBS_libxenutil) $(LDLIBS_libxenlight) $(LDLIBS_libxentoollog) -lyajl $(APPEND_LDFLAGS)
+	$(CC) $(LDFLAGS) -o $@ $(XL_OBJS) $(LDLIBS_libxenutil) $(LDLIBS_libxenlight) $(LDLIBS_libxentoollog) $(LDLIBS_libxenvchan) -lyajl $(APPEND_LDFLAGS)
 
 .PHONY: install
 install: all


### PR DESCRIPTION
This work introduces **Xenpcid daemon** that acts as a server for the client in the libxl PCI. The toolstack in Dom0 accesses sysfs to get information about PCI devices and in case of DomD that sysfs lives in DomD, so Dom0 can't read that information anymore. For that reason we introduce a "proxy" which directs requests from Dom0 to the domain which owns PCI devices, being it Dom0 itself or any other domain, e.g. DomD. Xenpcid is based on vchan-node2 tool and uses the libxenvchan library for messaging transport.
It was verified that this model works both remotely (in different domains) and locally (within one domain) as requested by Xen community [1]. The server processes the requests that come from the client. For now libxl PCI refers to sysfs in the following functions, therefore such a subset was implemented in Xenpcid commands handling:
- ‘ls’ - the server receives "dir_id" as parameter. Client cannot pass the sysfs path, as it is not the same on different operating systems. Therefore, for example, we pass parameter "pciback_driver" and on the server side we refer to "/sys/bus/pci/drivers/pciback" if Linux is used);
- ‘write’- the server receives the file name and value as parameters where and what to write;
- ‘read_hex’ - xenpcid returns hex value read from the given path;
- ‘exists’ - check the path for existing;
- ‘read_resources’ - returns an array of PCI device resources (start, end, flags) read from given path;
- ‘unbind’ - unbinds PCI device;
- ‘reset’ - resets PCI device.

Requests and responses are formed in the form of a json which is already used by libxenlight (xl). The commands are aimed at preventing the libxl PCI from reading / writing from / to the local sysfs directly. To do this, the libxl PCI itself was changed - instead of working with the read and write functions from / to the sysfs, functionality was added to send requests to the server, then receive and process the response.
Please note, that in current implementation there is a _security issue_: always only Dom0 can send messages to the channel, but we have Hardware Domain as a trusted entity. However, additional policies are needed to ensure the correct access to the channel.
_The issue of simultaneous access_ of several processes to the channel is not resolved as well. For example, the commands “xl pci-assignable-list” and “xl pci-assignable-add” will be sent at the same time. Due to the fact that there is only one channel, the processing of two requests will cause undefined behavior on the server side. In the future, it is necessary to take into account cases when from different domains there can be several requests from a client at the same time.
Also the presentation of the structures and some of the functions were taken from Libxl internal files. It will be necessary to make this code common to _avoid duplicates._
[1] - https://www.mail-archive.com/xen-devel@lists.xenproject.org/msg84452.html