### PR TITLE
xsm: Add Flask policy

### DIFF
--- a/tools/flask/policy/modules/domD.te
+++ b/tools/flask/policy/modules/domD.te
@@ -1,0 +1,32 @@
+###############################################################################
+#
+# Domain creation
+#
+###############################################################################
+
+declare_domain(domD_t)
+domain_self_comms(domD_t)
+create_domain(dom0_t, domD_t)
+manage_domain(dom0_t, domD_t)
+domain_comms(dom0_t, domD_t)
+domain_comms(domD_t, domD_t)
+migrate_domain_out(dom0_t, domD_t)
+domain_self_comms(domD_t)
+
+# This is required for PCI (or other device) passthrough
+delegate_devices(dom0_t, domD_t)
+
+# Domain type can be created using the default (system) role
+role system_r types { domD_t };
+
+use_device_iommu_nointremap(domD_t, irq_t)
+use_device_iommu_nointremap(domD_t, iomem_t)
+use_device_iommu_nointremap(domD_t, device_t)
+use_device_iommu_nointremap(domD_t, ioport_t)
+
+domain_comms(domD_t, domU_t)
+allow domD_t domU_t:mmu { map_read map_write };
+allow domD_t domU_t:domain2 resource_map;
+allow domD_t domU_t_channel:event create;
+allow domD_t domU_t:hvm dm;
+allow domD_t xen_t:xen physinfo;

--- a/tools/flask/policy/modules/modules.conf
+++ b/tools/flask/policy/modules/modules.conf
@@ -24,6 +24,7 @@ guest_features = on
 # This is required if you want to be able to create domains without specifying
 # their XSM label in the configuration.
 domU = on
+domD = on
 
 # Example types with restrictions
 isolated_domU = on

--- a/xen/arch/arm/dm.c
+++ b/xen/arch/arm/dm.c
@@ -45,7 +45,7 @@ int dm_op(const struct dmop_args *op_args)
     if ( rc )
         return rc;
 
-    rc = xsm_dm_op(XSM_HOOK, d);
+    rc = xsm_dm_op(XSM_DM_PRIV, d);
     if ( rc )
         goto out;
 

--- a/xen/arch/arm/mm.c
+++ b/xen/arch/arm/mm.c
@@ -1446,7 +1446,7 @@ int xenmem_add_to_physmap_one(
             return -EINVAL;
         }
 
-        rc = xsm_map_gmfn_foreign(XSM_HOOK, d, od);
+        rc = xsm_map_gmfn_foreign(XSM_TARGET, d, od);
         if ( rc )
         {
             put_pg_owner(od);

--- a/xen/arch/x86/hvm/dm.c
+++ b/xen/arch/x86/hvm/dm.c
@@ -370,7 +370,7 @@ int dm_op(const struct dmop_args *op_args)
     if ( !is_hvm_domain(d) )
         goto out;
 
-    rc = xsm_dm_op(XSM_HOOK, d);
+    rc = xsm_dm_op(XSM_DM_PRIV, d);
     if ( rc )
         goto out;
 

--- a/xen/arch/x86/mm/p2m.c
+++ b/xen/arch/x86/mm/p2m.c
@@ -2611,7 +2611,7 @@ static int p2m_add_foreign(struct domain *tdom, unsigned long fgfn,
             goto out;
     }
 
-    rc = xsm_map_gmfn_foreign(XSM_HOOK, tdom, fdom);
+    rc = xsm_map_gmfn_foreign(XSM_TARGET, tdom, fdom);
     if ( rc )
         goto out;
 

--- a/xen/common/event_channel.c
+++ b/xen/common/event_channel.c
@@ -300,7 +300,7 @@ static long evtchn_alloc_unbound(evtchn_alloc_unbound_t *alloc)
         ERROR_EXIT_DOM(port, d);
     chn = evtchn_from_port(d, port);
 
-    rc = xsm_evtchn_unbound(XSM_HOOK, d, chn, alloc->remote_dom);
+    rc = xsm_evtchn_unbound(XSM_TARGET, d, chn, alloc->remote_dom);
     if ( rc )
         goto out;
 
@@ -1375,7 +1375,7 @@ int alloc_unbound_xen_event_channel(
         goto out;
     chn = evtchn_from_port(ld, port);
 
-    rc = xsm_evtchn_unbound(XSM_HOOK, ld, chn, remote_domid);
+    rc = xsm_evtchn_unbound(XSM_TARGET, ld, chn, remote_domid);
     if ( rc )
         goto out;
 

--- a/xen/common/memory.c
+++ b/xen/common/memory.c
@@ -1222,7 +1222,7 @@ static int acquire_resource(
     if ( rc )
         return rc;
 
-    rc = xsm_domain_resource_map(XSM_HOOK, d);
+    rc = xsm_domain_resource_map(XSM_DM_PRIV, d);
     if ( rc )
         goto out;
 

--- a/xen/include/xsm/dummy.h
+++ b/xen/include/xsm/dummy.h
@@ -139,18 +139,13 @@ static XSM_INLINE int xsm_domctl(XSM_DEFAULT_ARG struct domain *d, int cmd)
     XSM_ASSERT_ACTION(XSM_OTHER);
     switch ( cmd )
     {
-    /*
-     * XXX: Emulator running in driver domain tries to get vcpus num.
-     * Probably we could avoid that change by modifying emulator to not use
-     * domctl for getting vcpus num.
-     */
-    case XEN_DOMCTL_getdomaininfo:
-        return xsm_default_action(XSM_HOOK, current->domain, d);
     case XEN_DOMCTL_ioport_mapping:
     case XEN_DOMCTL_memory_mapping:
     case XEN_DOMCTL_bind_pt_irq:
     case XEN_DOMCTL_unbind_pt_irq:
         return xsm_default_action(XSM_DM_PRIV, current->domain, d);
+    case XEN_DOMCTL_getdomaininfo:
+        return xsm_default_action(XSM_XS_PRIV, current->domain, d);
     default:
         return xsm_default_action(XSM_PRIV, current->domain, d);
     }
@@ -280,7 +275,7 @@ static XSM_INLINE int xsm_claim_pages(XSM_DEFAULT_ARG struct domain *d)
 static XSM_INLINE int xsm_evtchn_unbound(XSM_DEFAULT_ARG struct domain *d, struct evtchn *chn,
                                          domid_t id2)
 {
-    XSM_ASSERT_ACTION(XSM_HOOK);
+    XSM_ASSERT_ACTION(XSM_TARGET);
     return xsm_default_action(action, current->domain, d);
 }
 
@@ -540,7 +535,7 @@ static XSM_INLINE int xsm_remove_from_physmap(XSM_DEFAULT_ARG struct domain *d1,
 
 static XSM_INLINE int xsm_map_gmfn_foreign(XSM_DEFAULT_ARG struct domain *d, struct domain *t)
 {
-    XSM_ASSERT_ACTION(XSM_HOOK);
+    XSM_ASSERT_ACTION(XSM_TARGET);
     return xsm_default_action(action, d, t);
 }
 
@@ -716,7 +711,7 @@ static XSM_INLINE int xsm_pmu_op (XSM_DEFAULT_ARG struct domain *d, unsigned int
 
 static XSM_INLINE int xsm_dm_op(XSM_DEFAULT_ARG struct domain *d)
 {
-    XSM_ASSERT_ACTION(XSM_HOOK);
+    XSM_ASSERT_ACTION(XSM_DM_PRIV);
     return xsm_default_action(action, current->domain, d);
 }
 
@@ -772,6 +767,6 @@ static XSM_INLINE int xsm_xen_version (XSM_DEFAULT_ARG uint32_t op)
 
 static XSM_INLINE int xsm_domain_resource_map(XSM_DEFAULT_ARG struct domain *d)
 {
-    XSM_ASSERT_ACTION(XSM_HOOK);
+    XSM_ASSERT_ACTION(XSM_DM_PRIV);
     return xsm_default_action(action, current->domain, d);
 }


### PR DESCRIPTION
Add security policy file for DomD. Based on the default DomU
configuration and extended with the following access control and
interactions rules:

domD -> domU: tclass=domain (getdomaininfo)
domD -> domU: tclass=hvm (dm)
domD -> domU: tclass=event (create)
domD -> domU: tclass=domain2 (resource_map)
domD -> domU: tclass=mmu (map_read, map_write)

@otyshchenko1 
@lorc 
@andr2000
