### PR TITLE
xen/arm: platform: Add support for R-Car Gen4

### DIFF
--- a/xen/arch/arm/platforms/Kconfig
+++ b/xen/arch/arm/platforms/Kconfig
@@ -29,6 +29,14 @@ config RCAR3
 	---help---
 	Enable all the required drivers for Renesas RCar3
 
+config RCAR4
+	bool "Renesas RCar4 support"
+	depends on ARM_64
+	select HAS_SCIF
+	select IPMMU_VMSA
+	---help---
+	Enable all the required drivers for Renesas RCar4
+
 config MPSOC
 	bool "Xilinx Ultrascale+ MPSoC support"
 	depends on ARM_64
@@ -56,3 +64,6 @@ config MPSOC_PLATFORM
 	bool
 	default (ALL64_PLAT || MPSOC)
 
+config RCAR4_PLATFORM
+	bool
+	default (ALL64_PLAT || RCAR4)

--- a/xen/arch/arm/platforms/Makefile
+++ b/xen/arch/arm/platforms/Makefile
@@ -11,3 +11,4 @@ obj-$(CONFIG_ALL64_PLAT) += xgene-storm.o
 obj-$(CONFIG_ALL64_PLAT) += brcm-raspberry-pi.o
 obj-$(CONFIG_MPSOC_PLATFORM)  += xilinx-zynqmp.o
 obj-$(CONFIG_MPSOC_PLATFORM)  += xilinx-zynqmp-eemi.o
+obj-$(CONFIG_RCAR4_PLATFORM) += rcar4.o

--- a/xen/arch/arm/platforms/rcar4.c
+++ b/xen/arch/arm/platforms/rcar4.c
@@ -1,0 +1,38 @@
+#include <asm/platform.h>
+#include <xen/vmap.h>
+#include <asm/io.h>
+
+#define RST_BASE        0xE6160000
+#define RST_SRESCR0     (RST_BASE + 0x18)
+#define RST_SPRES       0x5AA58000
+
+static void rcar4_reset(void)
+{
+    void __iomem *addr;
+
+    addr = ioremap_nocache(RST_SRESCR0, sizeof(uint64_t));
+
+    if ( !addr )
+    {
+        printk("Gen4: Unable to map reset address\n");
+        return;
+    }
+
+    /* Write reset mask to base address */
+    writel(RST_SPRES, addr);
+
+    ASSERT_UNREACHABLE();
+}
+
+static const char * const rcar4_dt_compat[] __initconst =
+{
+    "renesas,spider-breakout",
+    "renesas,spider-cpu",
+    "renesas,r8a779f0",
+    NULL
+};
+
+PLATFORM_START(rcar4, "Renesas R-Car Gen4")
+    .compatible = rcar4_dt_compat,
+    .reset = rcar4_reset,
+PLATFORM_END


### PR DESCRIPTION
Implement system reset as it is done by U-boot as it is not yet
possible to use PSCI.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>