### PR TITLE
Fix ATU accesses by adding delay

### DIFF
--- a/xen/arch/arm/pci/pci-host-rcar4.c
+++ b/xen/arch/arm/pci/pci-host-rcar4.c
@@ -291,6 +291,11 @@ static void dw_pcie_prog_outbound_atu_unroll(struct pci_host_bridge *pci,
                              PCIE_ATU_ENABLE);
 
     /*
+     * HACK: We need to delay there, because the next code does not
+     * work as expected on S4
+     */
+    mdelay(1);
+    /*
      * Make sure ATU enable takes effect before any subsequent config
      * and I/O accesses.
      */

--- a/xen/arch/arm/pci/pci-host-rcar4.c
+++ b/xen/arch/arm/pci/pci-host-rcar4.c
@@ -387,7 +387,7 @@ static void __iomem *rcar4_child_map_bus(struct pci_host_bridge *bridge,
     int type;
 
     busdev = PCIE_ATU_BUS(sbdf.bus) | PCIE_ATU_DEV(PCI_SLOT(sbdf.devfn)) |
-        PCIE_ATU_FUNC(PCI_FUNC(sbdf.devfn));
+        PCIE_ATU_FUNC(0);
 
     /* TODO: Correct method to determine root bus. */
     if (sbdf.bus <= 1)
@@ -398,7 +398,7 @@ static void __iomem *rcar4_child_map_bus(struct pci_host_bridge *bridge,
                               type, bridge->child_cfg->phys_addr,
                               busdev, bridge->child_cfg->size);
 
-    return bridge->child_cfg->win + where;
+    return bridge->child_cfg->win + ((uint32_t)sbdf.fn << 16) + where;
 }
 
 static int rcar4_child_config_read(struct pci_host_bridge *bridge,

--- a/xen/arch/arm/pci/pci-host-rcar4.c
+++ b/xen/arch/arm/pci/pci-host-rcar4.c
@@ -368,6 +368,14 @@ static void dw_pcie_prog_outbound_atu(struct pci_host_bridge *pci, int index,
                                       int type, uint64_t cpu_addr,
                                       uint64_t pci_addr, uint64_t size)
 {
+    static uint64_t prev_addr = ~0;
+
+    /* Simple optimization to not-program ATU for every transaction */
+    if (prev_addr == pci_addr)
+        return;
+
+    prev_addr = pci_addr;
+
     __dw_pcie_prog_outbound_atu(pci, 0, index, type,
                                 cpu_addr, pci_addr, size);
 }


### PR DESCRIPTION
There is a delay needed after configuring ATU region, before accessing memory in that region.

To decrease possible performance impact we can minimize number of ATU reconfigurations:

 - By skipping configuration if it equals to a previous one
 - By configuring ATU in a such way, that all 8 PCI functions can be accessed at the same time