### PR TITLE
vscmi: make the freq/power ratio monotonically decreasing

### DIFF
--- a/xen/arch/arm/vscmi.c
+++ b/xen/arch/arm/vscmi.c
@@ -256,7 +256,7 @@ static void handle_perf_req(struct scmi_shared_mem *data)
         for ( i = 0; i < resp->num_returned; i++ )
         {
             resp->opp[i].perf_val = idx + i + 1;
-            resp->opp[i].power = resp->opp[i].perf_val;
+            resp->opp[i].power = resp->opp[i].perf_val * resp->opp[i].perf_val;
             resp->opp[i].transition_latency_us = cpu_to_le16(1);
         }
 


### PR DESCRIPTION
Some guest operating systems uses the power information transmitted over SCMI to decide wheter or not an OPP shall be used or not.

Notably, the Linux kernel expects that frequency / power ratio to be monotonically decreasing  - i.e., that OPPs operating at lower frequencies are more efficient than the ones at higher frequencies. If this is not true for a specific OPP, the kernel marks it as not efficient, possibly avoiding to use it.

Since the current implementation in Xen uses the OPP index as power value and the OPP frequencies are equally spaced, the aforementioned ratio is equal for all the exposed OPPs and they are all marked as inefficient except the first one.

Fix this behaviour using the square of the index as power value; while this does not have any physical meaning, it ensures the correct trend in OPP efficiency.

Signed-off-by: Francesco Valla <francesco.valla@mta.it>