### PR TITLE
Fix issue with SR-IOV interrupts

### DIFF
--- a/xen/arch/arm/gic-v3-its.c
+++ b/xen/arch/arm/gic-v3-its.c
@@ -318,6 +318,19 @@ static int its_send_cmd_inv(struct host_its *its,
     return its_send_command(its, cmd);
 }
 
+static int its_send_cmd_invall(struct host_its *its,
+                               uint32_t collection_id)
+{
+    uint64_t cmd[4];
+
+    cmd[0] = GITS_CMD_INVALL;
+    cmd[1] = 0x00;
+    cmd[2] = collection_id;
+    cmd[3] = 0x00;
+
+    return its_send_command(its, cmd);
+}
+
 /* Set up the (1:1) collection mapping for the given host CPU. */
 int gicv3_its_setup_collection(unsigned int cpu)
 {
@@ -708,7 +721,9 @@ static int gicv3_its_map_host_events(struct host_its *its,
             return ret;
     }
 
-    /* TODO: Consider using INVALL here. Didn't work on the model, though. */
+    ret = its_send_cmd_invall(its, 0);
+    if ( ret )
+        return ret;
 
     ret = its_send_cmd_sync(its, 0);
     if ( ret )

--- a/xen/arch/arm/gic-v3-its.c
+++ b/xen/arch/arm/gic-v3-its.c
@@ -190,8 +190,7 @@ static int its_send_command(struct host_its *hw_its, const void *its_cmd)
 
     memcpy(hw_its->cmd_buf + writep, its_cmd, ITS_CMD_SIZE);
     if ( hw_its->flags & HOST_ITS_FLUSH_CMD_QUEUE )
-        clean_and_invalidate_dcache_va_range(hw_its->cmd_buf + writep,
-                                             ITS_CMD_SIZE);
+        clean_dcache_va_range(hw_its->cmd_buf + writep, ITS_CMD_SIZE);
     else
         dsb(ishst);
 

--- a/xen/drivers/vpci/arm_vmsi.c
+++ b/xen/drivers/vpci/arm_vmsi.c
@@ -139,6 +139,7 @@ int vpci_msix_arch_enable_entry(struct vpci_msix_entry *entry,
     ret = vpci_get_msi_base(pdev, &msi_base);
     if ( ret )
     {
+        iounmap(desc_addr);
         return ret;
     }
 


### PR DESCRIPTION
There was issue regarding non-working interrupts for PCIe device after virtual SR-IOV function was enabled.

Looks like it was caused by missing INVALL command to ITS. This PR includes patch with INVALL call and couple of minor fixes that were discovered during debugging