### PR TITLE
giv3-its: flush all buffers, not just command queue

### DIFF
--- a/xen/arch/arm/include/asm/gic_v3_its.h
+++ b/xen/arch/arm/include/asm/gic_v3_its.h
@@ -109,7 +109,7 @@
 #include <xen/device_tree.h>
 #include <xen/rbtree.h>
 
-#define HOST_ITS_FLUSH_CMD_QUEUE        (1U << 0)
+#define HOST_ITS_FLUSH_BUFFERS          (1U << 0)
 #define HOST_ITS_USES_PTA               (1U << 1)
 
 #define HOST_ITS_WORKAROUND_NC_NS       (1U << 0)


### PR DESCRIPTION
ITS manages Device Tables and Interrupt Translation Tables on its own, so generally we are not interested which shareability and cacheability attributes it use. But there is one exception: ITS requires that DT and ITT must be initialized with zeroes. If ITS belongs to the Inner Cacheability domain there is problem at all.

But in all other cases we need to do clean CPU caches manually, or otherwise CPU can overwrite DT and ITT entries. From user perspective this looks like we are not receiving interrupts.

Also, we will rename HOST_ITS_FLUSH_CMD_QUEUE flag to HOST_ITS_FLUSH_BUFFERS because now this flag controls not only command queue.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>