### PR TITLE
libxl: Update xl devd to also spawn Qemu for Virtio devices

### DIFF
--- a/tools/libs/light/libxl_create.c
+++ b/tools/libs/light/libxl_create.c
@@ -1676,6 +1676,7 @@ static void domcreate_launch_dm(libxl__egc *egc, libxl__multidev *multidev,
     libxl__domain_create_state *dcs = CONTAINER_OF(multidev, *dcs, multidev);
     STATE_AO_GC(dcs->ao);
     int i;
+    bool dmargs_saved = false;
 
     /* convenience aliases */
     const uint32_t domid = dcs->guest_domid;
@@ -1768,9 +1769,24 @@ static void domcreate_launch_dm(libxl__egc *egc, libxl__multidev *multidev,
         libxl__device_add(gc, domid, &libxl__pvcallsif_devtype,
                           &d_config->pvcallsifs[i]);
 
-    for (i = 0; i < d_config->num_virtios; i++)
-        libxl__device_add(gc, domid, &libxl__virtio_devtype,
-                          &d_config->virtios[i]);
+    for (i = 0; i < d_config->num_virtios; i++) {
+        libxl_device_virtio *virtio = &d_config->virtios[i];
+
+        if (virtio->backend_type == LIBXL_VIRTIO_BACKEND_QEMU &&
+            virtio->backend_domid != LIBXL_TOOLSTACK_DOMID && !dmargs_saved) {
+
+            ret = libxl__save_qdisk_backend_dm_args(gc, domid,
+                                                    virtio->backend_domid,
+                                                    &d_config->b_info);
+            if (ret) {
+                LOGD(ERROR, domid, "Unable to save dm_args for Qdisk backend");
+                goto error_out;
+            }
+            dmargs_saved = true;
+        }
+
+        libxl__device_add(gc, domid, &libxl__virtio_devtype, virtio);
+    }
 
     switch (d_config->c_info.type) {
     case LIBXL_DOMAIN_TYPE_HVM:

--- a/tools/libs/light/libxl_internal.h
+++ b/tools/libs/light/libxl_internal.h
@@ -756,7 +756,8 @@ typedef struct {
     (dev)->backend_kind == LIBXL__DEVICE_KIND_VFB || \
     (dev)->backend_kind == LIBXL__DEVICE_KIND_QUSB || \
     (dev)->backend_kind == LIBXL__DEVICE_KIND_9PFS || \
-    (dev)->backend_kind == LIBXL__DEVICE_KIND_VKBD)
+    (dev)->backend_kind == LIBXL__DEVICE_KIND_VKBD || \
+    (dev)->backend_kind == LIBXL__DEVICE_KIND_QVIRTIO)
 
 #define XC_PCI_BDF             "0x%x, 0x%x, 0x%x, 0x%x"
 #define PCI_DEVFN(slot, func)   ((((slot) & 0x1f) << 3) | ((func) & 0x07))
@@ -4159,6 +4160,7 @@ struct libxl__dm_spawn_state {
     libxl__dm_resume_state dmrs;
     /* filled in by user, must remain valid: */
     uint32_t guest_domid; /* domain being served */
+    uint32_t backend_domid;
     libxl_domain_config *guest_config;
     libxl__domain_build_state *build_state; /* relates to guest_domid */
     libxl__dm_spawn_cb *callback;
@@ -4198,6 +4200,11 @@ _hidden char *libxl__stub_dm_name(libxl__gc *gc, const char * guest_name);
 _hidden void libxl__spawn_qdisk_backend(libxl__egc *egc,
                                         libxl__dm_spawn_state *dmss);
 _hidden int libxl__destroy_qdisk_backend(libxl__gc *gc, uint32_t domid);
+
+_hidden int libxl__save_qdisk_backend_dm_args(libxl__gc *gc,
+                                              uint32_t domid,
+                                              uint32_t backend_domid,
+                                              const libxl_domain_build_info *guest_info);
 
 /*----- Domain creation -----*/
 

--- a/tools/libs/light/libxl_types_internal.idl
+++ b/tools/libs/light/libxl_types_internal.idl
@@ -36,6 +36,7 @@ libxl__device_kind = Enumeration("device_kind", [
     (18, "VIRTIO"),
     (19, "VGSX"),
     (20, "VCAMERA"),
+    (21, "QVIRTIO"),
     ])
 
 libxl__console_backend = Enumeration("console_backend", [

--- a/tools/libs/light/libxl_virtio.c
+++ b/tools/libs/light/libxl_virtio.c
@@ -55,7 +55,8 @@ static int libxl__device_from_virtio(libxl__gc *gc, uint32_t domid,
     device->devid           = virtio->devid;
     device->domid           = domid;
 
-    device->backend_kind    = LIBXL__DEVICE_KIND_VIRTIO;
+    device->backend_kind    = virtio->backend_type == LIBXL_VIRTIO_BACKEND_QEMU ?
+        LIBXL__DEVICE_KIND_QVIRTIO : LIBXL__DEVICE_KIND_VIRTIO;
     device->kind            = LIBXL__DEVICE_KIND_VIRTIO;
 
     return 0;


### PR DESCRIPTION
Currently xl devd only supports Qdisk backend in that regard. Extend support for Virtio devices those backends are running inside Qemu.

In order to run Qemu for providing Virtio devices we need to pass an extra parameters (dm_args, guest memory size and the number of vCPUs) to it. For that purpose store required parameters in local "device-model" directory in Xenstore.

Also introduce new backend_kind LIBXL__DEVICE_KIND_QVIRTIO to distinguish between Qemu based and standalone Virtio devices in add_device(). If adding an extra backend_kind is not welcome, then add_device() could be reworked to read an additional info from the Xenstore about backend_type to make sure that Qemu would only be spawned for LIBXL_VIRTIO_BACKEND_QEMU.

TODO: With reusing Qdisk backend functionality for Virtio backends we likely need to rename involved functions, entries in Xenstore, log files that contain qdisk in the name.