### PR TITLE
libxl: Wait for Qemu spawned by xl devd to be ready before continue

### DIFF
--- a/tools/libs/light/libxl_create.c
+++ b/tools/libs/light/libxl_create.c
@@ -1676,7 +1676,7 @@ static void domcreate_launch_dm(libxl__egc *egc, libxl__multidev *multidev,
     libxl__domain_create_state *dcs = CONTAINER_OF(multidev, *dcs, multidev);
     STATE_AO_GC(dcs->ao);
     int i;
-    bool dmargs_saved = false;
+    libxl_domid dm_domid_saved = INVALID_DOMID;
 
     /* convenience aliases */
     const uint32_t domid = dcs->guest_domid;
@@ -1773,7 +1773,8 @@ static void domcreate_launch_dm(libxl__egc *egc, libxl__multidev *multidev,
         libxl_device_virtio *virtio = &d_config->virtios[i];
 
         if (virtio->backend_type == LIBXL_VIRTIO_BACKEND_QEMU &&
-            virtio->backend_domid != LIBXL_TOOLSTACK_DOMID && !dmargs_saved) {
+            virtio->backend_domid != LIBXL_TOOLSTACK_DOMID &&
+            dm_domid_saved == INVALID_DOMID) {
 
             ret = libxl__save_qdisk_backend_dm_args(gc, domid,
                                                     virtio->backend_domid,
@@ -1782,10 +1783,18 @@ static void domcreate_launch_dm(libxl__egc *egc, libxl__multidev *multidev,
                 LOGD(ERROR, domid, "Unable to save dm_args for Qdisk backend");
                 goto error_out;
             }
-            dmargs_saved = true;
+            dm_domid_saved = virtio->backend_domid;
         }
 
         libxl__device_add(gc, domid, &libxl__virtio_devtype, virtio);
+    }
+
+    if (dm_domid_saved != INVALID_DOMID) {
+        ret = libxl__wait_for_qdisk_backend_ready(gc, domid, dm_domid_saved);
+        if (ret < 0) {
+            LOGD(ERROR, domid, "Qdisk backend didn't respond in time");
+            goto error_out;
+        }
     }
 
     switch (d_config->c_info.type) {

--- a/tools/libs/light/libxl_dm.c
+++ b/tools/libs/light/libxl_dm.c
@@ -3508,6 +3508,22 @@ out:
     return rc;
 }
 
+#define QDISK_BACKEND_START_TIMEOUT 10
+
+int libxl__wait_for_qdisk_backend_ready(libxl__gc *gc,
+                                        uint32_t domid,
+                                        uint32_t backend_domid)
+{
+    char *dm_path;
+
+    dm_path = DEVICE_MODEL_XS_PATH(gc, backend_domid, domid, "/state");
+
+    return libxl__xenstore_child_wait_deprecated(gc, domid,
+                                                 QDISK_BACKEND_START_TIMEOUT,
+                                                 "Qdisk backend", dm_path,
+                                                 "running", NULL, NULL, NULL);
+}
+
 void libxl__spawn_qdisk_backend(libxl__egc *egc, libxl__dm_spawn_state *dmss)
 {
     STATE_AO_GC(dmss->spawn.ao);

--- a/tools/libs/light/libxl_internal.h
+++ b/tools/libs/light/libxl_internal.h
@@ -4201,6 +4201,10 @@ _hidden void libxl__spawn_qdisk_backend(libxl__egc *egc,
                                         libxl__dm_spawn_state *dmss);
 _hidden int libxl__destroy_qdisk_backend(libxl__gc *gc, uint32_t domid);
 
+_hidden int libxl__wait_for_qdisk_backend_ready(libxl__gc *gc,
+                                                uint32_t domid,
+                                                uint32_t backend_domid);
+
 _hidden int libxl__save_qdisk_backend_dm_args(libxl__gc *gc,
                                               uint32_t domid,
                                               uint32_t backend_domid,


### PR DESCRIPTION
The toolstack shouldn't unpause guest until "non local" device-model (currently Qdisk backend) is up and running. As guest checks the availability of the Virtio devices (and discovers them) at the early stage and QEMU may not be completely initialized yet by that time. If that race happens the Virtio devices that Qemu is intended to emulate will never show up in the guest. This race has never been observed for Qemu running in the toolstack domain, maybe because of the QMP support that toolstack uses for the *local* device-model.

So, wait it to be ready by periodically checking the presence of "state=running" in Xenstore. Done this right after adding Virtio devices which in turn should trigger xl devd in driver domain to spawn Qemu.

TODO: Likely this could be done more nicely than current patch does, for example, to not use deprecated func, etc.