### PR TITLE
libxl/arm: adjust vpci IRQ map according to vgic config

### DIFF
--- a/tools/libs/light/libxl_arm.c
+++ b/tools/libs/light/libxl_arm.c
@@ -949,18 +949,37 @@ static int make_vpci_node_common(libxl__gc *gc, void *fdt,
 }
 
 #define PCI_NUM_IRQ   4
-#define PCI_IRQ_MAP_STRIDE   8
+#define PCI_IRQ_MAP_MIN_STRIDE   8
 #define PCI_IOMMU_MAP_STRIDE 4
 
 static int create_vpci_irq_map(libxl__gc *gc, void *fdt)
 {
-    uint32_t full_irq_map[PCI_NUM_IRQ * PCI_NUM_IRQ * PCI_IRQ_MAP_STRIDE] = {0};
-    uint32_t *irq_map = full_irq_map;
+    uint32_t *full_irq_map, *irq_map;
+    size_t len;
     unsigned int slot, pin;
-    int res;
+    int res, cells;
 
     res = fdt_property_cell(fdt, "#interrupt-cells", 1);
     if (res) return res;
+
+    /* assume GIC node to be present, due to
+     * make_gicv2_node()/make_gicv3_node() get called earlier
+     */
+    res = fdt_node_offset_by_phandle(fdt, GUEST_PHANDLE_GIC);
+    if (res < 0)
+        return res;
+
+    res = fdt_address_cells(fdt, res);
+    /* handle case of make_gicv2_node() setting #address-cells to 0 */
+    if (res == -FDT_ERR_BADNCELLS)
+        res = 0;
+    else if (res < 0)
+        return res;
+
+    cells = res;
+    len = sizeof(uint32_t) * PCI_NUM_IRQ * PCI_NUM_IRQ *
+          (PCI_IRQ_MAP_MIN_STRIDE + cells);
+    irq_map = full_irq_map = libxl__malloc(gc, len);
 
     for (slot = 0; slot < PCI_NUM_IRQ; slot++) {
         for (pin = 0; pin < PCI_NUM_IRQ; pin++) {
@@ -979,16 +998,19 @@ static int create_vpci_irq_map(libxl__gc *gc, void *fdt)
             /* GIC phandle (1 cell) */
             irq_map[i++] = cpu_to_fdt32(GUEST_PHANDLE_GIC);
 
+            /* GIC unit address, set 0 because vgic itself handles vpci IRQs */
+            for (int c = cells; c--; irq_map[i++] = cpu_to_fdt32(0));
+
             /* GIC interrupt (3 cells) */
             irq_map[i++] = cpu_to_fdt32(0); /* SPI */
             irq_map[i++] = cpu_to_fdt32(irq - 32);
             irq_map[i++] = cpu_to_fdt32(DT_IRQ_TYPE_LEVEL_HIGH);
 
-            irq_map += PCI_IRQ_MAP_STRIDE;
+            irq_map += PCI_IRQ_MAP_MIN_STRIDE + cells;
         }
     }
 
-    res = fdt_property(fdt, "interrupt-map", full_irq_map, sizeof(full_irq_map));
+    res = fdt_property(fdt, "interrupt-map", full_irq_map, len);
     if (res) return res;
 
     res = fdt_property_values(gc, fdt, "interrupt-map-mask", 4,


### PR DESCRIPTION
Calculate size of interrupt-map property and fill it taking into account address cells property of parent interrupt controller.

For compliance with device tree spec[1] parent unit address is also expected in interrupt map. Since in our VPCI case interrupts are handled by VGIC itself we set unit address to 0.

[1] Devicetree Specification, 2.4.3.1. interrupt-map