### PR TITLE
[NOT TESTED] arm/vpci: honor access size

### DIFF
--- a/xen/arch/arm/vpci.c
+++ b/xen/arch/arm/vpci.c
@@ -51,6 +51,8 @@ static int vpci_mmio_read(struct vcpu *v, mmio_info_t *info,
     pci_sbdf_t sbdf;
     /* data is needed to prevent a pointer cast on 32bit */
     unsigned long data;
+    const uint8_t access_size = (1 << info->dabt.size) * 8;
+    const uint64_t access_mask = GENMASK_ULL(access_size - 1, 0);
 
     ASSERT(!bridge == !is_hardware_domain(v->domain));
 
@@ -87,7 +89,7 @@ static int vpci_mmio_read(struct vcpu *v, mmio_info_t *info,
             }
 #endif
 
-            *r = ~0ul;
+            *r = access_mask;
             return rc;
         }
     }
@@ -99,7 +101,7 @@ static int vpci_mmio_read(struct vcpu *v, mmio_info_t *info,
         return 1;
     }
 
-    *r = ~0ul;
+    *r = access_mask;
 
     return 0;
 }


### PR DESCRIPTION
Guest can try to read config space using different access sizes: 8, 16, 32, 64 bits. We need to take this into account when we are returning data back to MMIO handler, otherwise it is possible to provide more data than requested: i.e. guest issues LDRB instruction to read one byte, but we are writing 0xFFFFFFFFFFFFFFFF in the target register.