### PR TITLE
arm/ioreq: clean data field in ioreq struct on read operations

### DIFF
--- a/xen/arch/arm/ioreq.c
+++ b/xen/arch/arm/ioreq.c
@@ -80,7 +80,7 @@ enum io_state try_fwd_ioserv(struct cpu_user_regs *regs,
 
     ASSERT(dabt.valid);
 
-    p.data = get_user_reg(regs, info->dabt.reg);
+    p.data = (p.dir) ? 0 : get_user_reg(regs, info->dabt.reg);
     vio->req = p;
     vio->suspended = false;
     vio->info.dabt_instr = instr;


### PR DESCRIPTION
For read operations, there's a potential issue when the data field of the ioreq struct is partially updated in the response. To address this, zero data field during read operations. This modification serves as a safeguard against implementations that may inadvertently partially update the data field in response to read requests. For instance, consider an 8-bit read operation. In such cases, QEMU, returns the same content of the dat field with only 8 bits of updated data. This behavior could potentially result in the propagation of incorrect or unintended data to user-space applications.