### PR TITLE
xen/domain: Save PMU counters to mdcr_el2

### DIFF
--- a/xen/arch/arm/domain.c
+++ b/xen/arch/arm/domain.c
@@ -592,6 +592,9 @@ int arch_vcpu_create(struct vcpu *v)
     v->arch.mdcr_el2 = HDCR_TDRA | HDCR_TDOSA | HDCR_TDA;
     if ( !(v->domain->options & XEN_DOMCTL_CDF_vpmu) )
         v->arch.mdcr_el2 |= HDCR_TPM | HDCR_TPMCR;
+    else
+        v->arch.mdcr_el2 |= (READ_SYSREG(PMCR_EL0) >> ARMV8_PMU_PMCR_N_SHIFT) &
+                             ARMV8_PMU_PMCR_N_MASK;
 
     if ( (rc = vcpu_vgic_init(v)) != 0 )
         goto fail;

--- a/xen/arch/arm/include/asm/arm64/sysregs.h
+++ b/xen/arch/arm/include/asm/arm64/sysregs.h
@@ -388,6 +388,9 @@
 #define DCZID_DZP_SHIFT              4
 #define DCZID_BS_SHIFT               0
 
+#define ARMV8_PMU_PMCR_N_SHIFT       11
+#define ARMV8_PMU_PMCR_N_MASK        0x1F
+
 /*
  * The ZCR_ELx_LEN_* definitions intentionally include bits [8:4] which
  * are reserved by the SVE architecture for future expansion of the LEN


### PR DESCRIPTION
According to arm documentation
"When EL2 is implemented and enabled for the current
 Security state, reads of this field from EL1
 and EL0 return the value of MDCR_EL2.HPMN."

To be able to use PMU counters from guest domain, the counters should be read from pmcr_el0 register and saved to mdcr_el2.