### PR TITLE
xen/arm: Add a cmd param to disable GSX IRQ support

### DIFF
--- a/xen/arch/arm/irq.c
+++ b/xen/arch/arm/irq.c
@@ -16,6 +16,7 @@
 #include <xen/errno.h>
 #include <xen/sched.h>
 #include <xen/vmap.h>
+#include <xen/param.h>
 
 #include <asm/io.h>
 #include <asm/gic.h>
@@ -25,6 +26,10 @@ const unsigned int nr_irqs = NR_IRQS;
 
 static unsigned int local_irqs_type[NR_LOCAL_IRQS];
 static DEFINE_SPINLOCK(local_irqs_type_lock);
+
+/* If true, the GSX IRQ support is enabled for the guests */
+bool opt_rcar3_gsx = true;
+boolean_param("rcar3_gsx", opt_rcar3_gsx);
 
 #define GSX_MAX_OS_CNT                                     8
 #define GSX_REG_BASE_ADDR                         0xfd000000
@@ -336,6 +341,12 @@ void init_gsx_interrupt(void)
 {
     const uint32_t irq_reg_offset[GSX_MAX_OS_CNT] = GSX_OS_IRQ_CNT_REGS;
     int i, ret;
+
+    if ( !opt_rcar3_gsx )
+    {
+        printk(XENLOG_INFO "GSX IRQ is disabled\n");
+        return;
+    }
 
     gsx_reg_base = ioremap_nocache(GSX_REG_BASE_ADDR, GSX_REG_BANK_SIZE);
     if ( !gsx_reg_base )
@@ -667,7 +678,7 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
         }
         else
         {
-            if ( irq == gsx_irq_num )
+            if ( opt_rcar3_gsx && irq == gsx_irq_num )
                 retval = add_gsx_domain(d);
             else
             {

--- a/xen/arch/arm/vgic.c
+++ b/xen/arch/arm/vgic.c
@@ -168,6 +168,7 @@ void register_vgic_ops(struct domain *d, const struct vgic_ops *ops)
    d->arch.vgic.handler = ops;
 }
 
+extern bool opt_rcar3_gsx;
 extern const int gsx_irq_num;
 extern void remove_gsx_domain(struct domain *d);
 
@@ -180,7 +181,7 @@ void domain_vgic_free(struct domain *d)
     {
         struct pending_irq *p = spi_to_pending(d, i + 32);
 
-        if ( p->irq == gsx_irq_num )
+        if ( opt_rcar3_gsx && p->irq == gsx_irq_num )
             remove_gsx_domain(d);
 
         if ( p->desc )


### PR DESCRIPTION
By default the GSX IRQ support is enabled. Disable it (rcar3_gsx=false) if you are going to use GPU passthrough instead of sharing.

Additionally GSX driver in the guest should be run in native mode.