### PR TITLE
SCMI-Mediator add support for DomUs

### DIFF
--- a/docs/man/xl.cfg.5.pod.in
+++ b/docs/man/xl.cfg.5.pod.in
@@ -1715,6 +1715,28 @@ Specifies OS ID.
 
 =back
 
+=item B<arm_sci="STRING">
+
+B<Arm only> Set ARM_SCI type for the guest. ARM_SCI is System Control Protocol
+allows domain to manage various functions that are provided by HW platform.
+
+=over 4
+
+=item B<none>
+
+Don't allow guest to use ARM_SCI if present on the platform. This is the
+default value.
+
+=item B<scmi_smc>
+
+Enables SCMI_SMC support for the guest. SCMI is System Control Management
+Inferface - allows domain to manage various functions that are provided by HW
+platform, such as clocks, resets and power-domains. Xen will mediate access to
+clocks, power-domains and resets between Domains and ATF. Disabled by default.
+SCP is used as transport.
+
+=back
+
 =back
 
 =head2 Paravirtualised (PV) Guest Specific Options

--- a/tools/golang/xenlight/helpers.gen.go
+++ b/tools/golang/xenlight/helpers.gen.go
@@ -1127,6 +1127,8 @@ if err := x.DmRestrict.fromC(&xc.dm_restrict);err != nil {
 return fmt.Errorf("converting field DmRestrict: %v", err)
 }
 x.Tee = TeeType(xc.tee)
+x.ArmSci = ArmSciType(xc.arm_sci)
+
 x.Type = DomainType(xc._type)
 switch x.Type{
 case DomainTypeHvm:
@@ -1485,6 +1487,7 @@ if err := x.DmRestrict.toC(&xc.dm_restrict); err != nil {
 return fmt.Errorf("converting field DmRestrict: %v", err)
 }
 xc.tee = C.libxl_tee_type(x.Tee)
+xc.arm_sci = C.libxl_arm_sci_type(x.ArmSci)
 xc._type = C.libxl_domain_type(x.Type)
 switch x.Type{
 case DomainTypeHvm:

--- a/tools/golang/xenlight/types.gen.go
+++ b/tools/golang/xenlight/types.gen.go
@@ -513,6 +513,12 @@ SveType1920 SveType = 1920
 SveType2048 SveType = 2048
 )
 
+type ArmSciType int
+const(
+ArmSciTypeNone ArmSciType = 0
+ArmSciTypeScmi ArmSciType = 1
+)
+
 type RdmReserve struct {
 Strategy RdmReserveStrategy
 Policy RdmReservePolicy
@@ -584,6 +590,7 @@ NestedHvm Defbool
 Apic Defbool
 DmRestrict Defbool
 Tee TeeType
+ArmSci ArmSciType
 Type DomainType
 TypeUnion DomainBuildInfoTypeUnion
 ArchArm struct {

--- a/tools/include/libxl.h
+++ b/tools/include/libxl.h
@@ -309,6 +309,11 @@
 #define LIBXL_HAVE_BUILDINFO_ARCH_ARM_SVE_VL 1
 
 /*
+ * libxl_domain_build_info has the arch_arm.sci field.
+ */
+#define LIBXL_HAVE_BUILDINFO_ARCH_ARM_SCI 1
+
+/*
  * LIBXL_HAVE_SOFT_RESET indicates that libxl supports performing
  * 'soft reset' for domains and there is 'soft_reset' shutdown reason
  * in enum libxl_shutdown_reason.

--- a/tools/include/xenctrl.h
+++ b/tools/include/xenctrl.h
@@ -1230,6 +1230,9 @@ int xc_domain_getvnuma(xc_interface *xch,
 int xc_domain_soft_reset(xc_interface *xch,
                          uint32_t domid);
 
+int xc_domain_get_sci_info(xc_interface *xch, uint32_t domid,
+                           uint64_t *paddr, uint32_t *func_id);
+
 #if defined(__i386__) || defined(__x86_64__)
 /*
  * PC BIOS standard E820 types and structure.

--- a/tools/libs/ctrl/xc_domain.c
+++ b/tools/libs/ctrl/xc_domain.c
@@ -2180,6 +2180,24 @@ int xc_domain_soft_reset(xc_interface *xch,
     domctl.domain = domid;
     return do_domctl(xch, &domctl);
 }
+
+int xc_domain_get_sci_info(xc_interface *xch, uint32_t domid,
+                            uint64_t *paddr, uint32_t *func_id)
+{
+    struct xen_domctl domctl = {};
+
+    memset(&domctl, 0, sizeof(domctl));
+    domctl.cmd = XEN_DOMCTL_get_sci_info;
+    domctl.domain = domid;
+
+    if ( do_domctl(xch, &domctl) != 0 )
+        return 1;
+
+    *paddr = domctl.u.sci_info.paddr;
+    *func_id = domctl.u.sci_info.func_id;
+    return 0;
+}
+
 /*
  * Local variables:
  * mode: C

--- a/tools/libs/hypfs/core.c
+++ b/tools/libs/hypfs/core.c
@@ -307,8 +307,6 @@ char *xenhypfs_read(xenhypfs_handle *fshdl, const char *path)
         errno = EISDIR;
         break;
     case xenhypfs_type_blob:
-        errno = EDOM;
-        break;
     case xenhypfs_type_string:
         ret_buf = buf;
         buf = NULL;

--- a/tools/libs/light/libxl_arm.c
+++ b/tools/libs/light/libxl_arm.c
@@ -9,6 +9,7 @@
 #include <libfdt.h>
 #include <assert.h>
 #include <xen/device_tree_defs.h>
+#include <xenhypfs.h>
 
 /*
  * There is no clear requirements for the total size of Virtio MMIO region.
@@ -350,6 +351,19 @@ int libxl__arch_domain_prepare_config(libxl__gc *gc,
         config->arch.vgsx_osid = vgsx->osid;
     } else
         config->arch.vgsx_osid = 0;
+
+    switch (d_config->b_info.arm_sci) {
+    case LIBXL_ARM_SCI_TYPE_NONE:
+        config->arch.arm_sci_type = XEN_DOMCTL_CONFIG_ARM_SCI_NONE;
+        break;
+    case LIBXL_ARM_SCI_TYPE_SCMI_SMC:
+        config->arch.arm_sci_type = XEN_DOMCTL_CONFIG_ARM_SCI_SCMI_SMC;
+        break;
+    default:
+        LOG(ERROR, "Unknown ARM_SCI type %d",
+            d_config->b_info.arm_sci);
+        return ERROR_FAIL;
+    }
 
     return 0;
 }
@@ -778,9 +792,6 @@ static int make_optee_node(libxl__gc *gc, void *fdt)
     int res;
     LOG(DEBUG, "Creating OP-TEE node in dtb");
 
-    res = fdt_begin_node(fdt, "firmware");
-    if (res) return res;
-
     res = fdt_begin_node(fdt, "optee");
     if (res) return res;
 
@@ -788,9 +799,6 @@ static int make_optee_node(libxl__gc *gc, void *fdt)
     if (res) return res;
 
     res = fdt_property_string(fdt, "method", "hvc");
-    if (res) return res;
-
-    res = fdt_end_node(fdt);
     if (res) return res;
 
     res = fdt_end_node(fdt);
@@ -1545,10 +1553,9 @@ static int copy_node(libxl__gc *gc, void *fdt, void *pfdt,
     return 0;
 }
 
-static int copy_node_by_path(libxl__gc *gc, const char *path,
-                             void *fdt, void *pfdt)
+static int get_path_nodeoff(const char *path, void *pfdt)
 {
-    int nodeoff, r;
+    int nodeoff;
     const char *name = strrchr(path, '/');
 
     if (!name)
@@ -1568,8 +1575,273 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
     if (strcmp(fdt_get_name(pfdt, nodeoff, NULL), name))
         return -FDT_ERR_NOTFOUND;
 
+    return nodeoff;
+}
+
+static int copy_node_by_path(libxl__gc *gc, const char *path,
+                             void *fdt, void *pfdt)
+{
+    int nodeoff, r;
+
+    nodeoff = get_path_nodeoff(path, pfdt);
+    if (nodeoff < 0)
+        return nodeoff;
+
     r = copy_node(gc, fdt, pfdt, nodeoff, 0);
     if (r) return r;
+
+    return 0;
+}
+
+static int map_sci_page(libxl__gc *gc, uint32_t domid, uint64_t paddr,
+                         uint64_t guest_addr)
+{
+    int ret;
+    uint64_t _paddr_pfn = paddr >> XC_PAGE_SHIFT;
+    uint64_t _guest_pfn = guest_addr >> XC_PAGE_SHIFT;
+
+    assert(paddr && guest_addr);
+    LOG(DEBUG, "[%d] mapping sci shmem page %"PRIx64, domid, _paddr_pfn);
+
+    ret = xc_domain_iomem_permission(CTX->xch, domid, _paddr_pfn, 1, 1);
+    if (ret < 0) {
+        LOG(ERROR,
+              "failed give domain access to iomem page %"PRIx64,
+             _paddr_pfn);
+        return ret;
+    }
+
+    ret = xc_domain_memory_mapping(CTX->xch, domid,
+                                   _guest_pfn, _paddr_pfn,
+                                   1, 1);
+    if (ret < 0) {
+        LOG(ERROR,
+              "failed to map to domain iomem page %"PRIx64
+              " to guest address %"PRIx64,
+              _paddr_pfn, _guest_pfn);
+        return ret;
+    }
+
+    return 0;
+}
+
+static int scmi_dt_make_shmem_node(libxl__gc *gc, void *fdt)
+{
+    int res;
+    char buf[64];
+
+    snprintf(buf, sizeof(buf), "scmi-shmem@%llx", GUEST_SCI_SHMEM_BASE);
+
+    res = fdt_begin_node(fdt, buf);
+    if (res) return res;
+
+    res = fdt_property_compat(gc, fdt, 1, "arm,scmi-shmem");
+    if (res) return res;
+
+    res = fdt_property_regs(gc, fdt, GUEST_ROOT_ADDRESS_CELLS,
+                    GUEST_ROOT_SIZE_CELLS, 1,
+                    GUEST_SCI_SHMEM_BASE, GUEST_SCI_SHMEM_SIZE);
+    if (res) return res;
+
+    res = fdt_property_cell(fdt, "phandle", GUEST_PHANDLE_SCMI);
+    if (res) return res;
+
+    res = fdt_end_node(fdt);
+    if (res) return res;
+
+    return 0;
+}
+
+static const char *name_from_path(const char *path)
+{
+    return strrchr(path, '/') + 1;
+}
+
+static int dt_copy_properties(libxl__gc *gc, void* fdt, void *xen_fdt,
+        const char *full_name)
+{
+    int propoff, nameoff, r, nodeoff;
+    const struct fdt_property *prop;
+
+    LOG(DEBUG, "Copy properties for node: %s", full_name);
+    nodeoff = get_path_nodeoff(full_name, xen_fdt);
+    if (nodeoff < 0)
+        return -FDT_ERR_NOTFOUND;
+
+    for (propoff = fdt_first_property_offset(xen_fdt, nodeoff);
+         propoff >= 0;
+         propoff = fdt_next_property_offset(xen_fdt, propoff)) {
+
+        if (!(prop = fdt_get_property_by_offset(xen_fdt, propoff, NULL)))
+            return -FDT_ERR_INTERNAL;
+
+        nameoff = fdt32_to_cpu(prop->nameoff);
+
+        /* Skipping phandle nodes in xen device-tree */
+        if (strcmp(fdt_string(xen_fdt,nameoff), "phandle") == 0 ||
+            strcmp(fdt_string(xen_fdt, nameoff), "linux,phandle") == 0)
+            continue;
+
+        r = fdt_property(fdt, fdt_string(xen_fdt, nameoff),
+                         prop->data, fdt32_to_cpu(prop->len));
+        if (r) return r;
+    }
+
+    return (propoff != -FDT_ERR_NOTFOUND)? propoff : 0;
+}
+
+static int scmi_dt_scan_node(libxl__gc *gc, void *fdt, void *pfdt,
+                             void *xen_fdt, int nodeoff)
+{
+    int rc;
+    int node_next;
+    char full_name[128];
+    uint32_t phandle;
+
+    node_next = fdt_first_subnode(pfdt, nodeoff);
+    while (node_next > 0)
+    {
+        LOG(DEBUG,"Processing node %s",
+                fdt_get_name(pfdt, node_next, NULL));
+
+        phandle = fdt_get_phandle(pfdt, node_next);
+
+        rc = fdt_get_path(pfdt, node_next, full_name, sizeof(full_name));
+        if (rc) return rc;
+
+        rc = fdt_begin_node(fdt, name_from_path(full_name));
+        if (rc) return rc;
+
+        rc = dt_copy_properties(gc, fdt, xen_fdt, full_name);
+        if (rc) return rc;
+
+        if (phandle) {
+            rc = fdt_property_cell(fdt, "phandle", phandle);
+            if (rc) return rc;
+        }
+
+        rc = scmi_dt_scan_node(gc, fdt, pfdt, xen_fdt, node_next);
+        if (rc) return rc;
+
+        rc = fdt_end_node(fdt);
+        if (rc) return rc;
+
+        node_next = fdt_next_subnode(pfdt, node_next);
+    }
+
+    return 0;
+}
+
+static int scmi_hypfs_fdt_check(libxl__gc *gc, void *fdt)
+{
+    int r;
+
+    if (fdt_magic(fdt) != FDT_MAGIC) {
+         LOG(ERROR, "FDT is not a valid Flat Device Tree");
+         return ERROR_FAIL;
+     }
+
+     r = fdt_check_header(fdt);
+     if (r) {
+         LOG(ERROR, "Failed to check the FDT (%d)", r);
+         return ERROR_FAIL;
+     }
+
+     return r;
+}
+
+static int scmi_dt_copy_subnodes(libxl__gc *gc, void *fdt, void *pfdt)
+{
+    struct xenhypfs_handle *hdl;
+    struct xenhypfs_dirent *ent;
+    void *xen_fdt;
+    int rc, nodeoff;
+
+    hdl = xenhypfs_open(NULL, 0);
+    if (!hdl)
+        return -EINVAL;
+
+    xen_fdt = xenhypfs_read_raw(hdl, "/devicetree", &ent);
+    if (!xen_fdt) {
+        rc = errno;
+        LOG(ERROR, "Unable to read hypfs entry: %d", rc);
+        goto out;
+    }
+
+    rc = scmi_hypfs_fdt_check(gc, xen_fdt);
+    if (rc) {
+        LOG(ERROR, "Hypfs device tree is invalid");
+        goto out;
+    }
+
+    nodeoff = get_path_nodeoff("/firmware/scmi", pfdt);
+    if (nodeoff <= 0) {
+        rc = -ENODEV;
+        goto out;
+    }
+
+    rc = scmi_dt_scan_node(gc, fdt, pfdt, xen_fdt, nodeoff);
+
+out:
+    xenhypfs_close(hdl);
+    return rc;
+}
+
+static int scmi_dt_create_node(libxl__gc *gc, void *fdt, void *pfdt,
+                               uint32_t func_id)
+{
+    int rc = 0;
+
+    rc = fdt_begin_node(fdt, "scmi");
+    if (rc) return rc;
+
+    rc = fdt_property_compat(gc, fdt, 1, "arm,scmi-smc");
+    if (rc) return rc;
+
+    rc = fdt_property_cell(fdt, "shmem", GUEST_PHANDLE_SCMI);
+    if (rc) return rc;
+
+    rc = fdt_property_cell(fdt, "#addrets-cells", 1);
+    if (rc) return rc;
+
+    rc = fdt_property_cell(fdt, "#size-cells", 0);
+    if (rc) return rc;
+
+    rc = fdt_property_cell(fdt, "arm,smc-id", func_id);
+    if (rc) return rc;
+
+    rc = scmi_dt_copy_subnodes(gc, fdt, pfdt);
+    if (rc) return rc;
+
+    rc = fdt_end_node(fdt);
+    if (rc) return rc;
+
+    return rc;
+}
+
+static int make_firmware_node(libxl__gc *gc, void *fdt, void *pfdt, int tee,
+                              int sci, uint32_t func_id)
+{
+    int res;
+
+    if ((tee == LIBXL_TEE_TYPE_NONE) && (sci == LIBXL_ARM_SCI_TYPE_NONE))
+        return 0;
+
+    res = fdt_begin_node(fdt, "firmware");
+    if (res) return res;
+
+    if (tee == LIBXL_TEE_TYPE_OPTEE) {
+       res = make_optee_node(gc, fdt);
+       if (res) return res;
+    }
+
+    if (sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
+        res = scmi_dt_create_node(gc, fdt, pfdt, func_id);
+        if (res) return res;
+    }
+
+    res = fdt_end_node(fdt);
+    if (res) return res;
 
     return 0;
 }
@@ -1745,8 +2017,11 @@ next_resize:
         if (info->arch_arm.vuart == LIBXL_VUART_TYPE_SBSA_UART)
             FDT( make_vpl011_uart_node(gc, fdt, ainfo, dom) );
 
-        if (info->tee == LIBXL_TEE_TYPE_OPTEE)
-            FDT( make_optee_node(gc, fdt) );
+        if (info->arm_sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC)
+            FDT( scmi_dt_make_shmem_node(gc, fdt) );
+
+        FDT( make_firmware_node(gc, fdt, pfdt, info->tee, info->arm_sci,
+                state->arm_sci_agent_funcid) );
 
         if (d_config->num_pcidevs)
             FDT( make_vpci_node(gc, fdt, ainfo, dom) );
@@ -2033,6 +2308,16 @@ int libxl__arch_build_dom_finish(libxl__gc *gc,
                                  libxl__domain_build_state *state)
 {
     int rc = 0, ret;
+
+    if (info->arm_sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
+        ret = map_sci_page(gc, dom->guest_domid, state->arm_sci_agent_paddr,
+                           GUEST_SCI_SHMEM_BASE);
+        if (ret < 0) {
+            LOG(ERROR, "map_sci_page failed\n");
+            rc = ERROR_FAIL;
+            goto out;
+        }
+    }
 
     if (info->arch_arm.vuart != LIBXL_VUART_TYPE_SBSA_UART) {
         rc = 0;

--- a/tools/libs/light/libxl_create.c
+++ b/tools/libs/light/libxl_create.c
@@ -774,6 +774,18 @@ int libxl__domain_make(libxl__gc *gc, libxl_domain_config *d_config,
      */
     assert(libxl_domid_valid_guest(*domid));
 
+    if (d_config->b_info.arm_sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
+        ret = xc_domain_get_sci_info(ctx->xch, *domid, &state->arm_sci_agent_paddr,
+                &state->arm_sci_agent_funcid);
+        LOGD(DEBUG, *domid,"sci_agent_paddr = %lx", state->arm_sci_agent_paddr);
+        if (ret) {
+            LOGED(ERROR, *domid, "failed to get sci paddr");
+            rc = ERROR_FAIL;
+            goto out;
+        }
+
+    }
+
     dom_path = libxl__xs_get_dompath(gc, *domid);
     if (!dom_path) {
         rc = ERROR_FAIL;

--- a/tools/libs/light/libxl_internal.h
+++ b/tools/libs/light/libxl_internal.h
@@ -1409,6 +1409,9 @@ typedef struct {
      * applicable to the primary domain, not support domains (e.g. stub QEMU). */
     bool restore;
     bool soft_reset;
+
+    uint64_t arm_sci_agent_paddr;
+    uint32_t arm_sci_agent_funcid;
 } libxl__domain_build_state;
 
 _hidden void libxl__domain_build_state_init(libxl__domain_build_state *s);

--- a/tools/libs/light/libxl_types.idl
+++ b/tools/libs/light/libxl_types.idl
@@ -552,6 +552,11 @@ libxl_sve_type = Enumeration("sve_type", [
     (2048, "2048")
     ], init_val = "LIBXL_SVE_TYPE_DISABLED")
 
+libxl_arm_sci_type = Enumeration("arm_sci_type", [
+    (0, "none"),
+    (1, "scmi_smc")
+    ], init_val = "LIBXL_ARM_SCI_TYPE_NONE")
+
 libxl_rdm_reserve = Struct("rdm_reserve", [
     ("strategy",    libxl_rdm_reserve_strategy),
     ("policy",      libxl_rdm_reserve_policy),
@@ -655,6 +660,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
     ("tee",              libxl_tee_type),
     ("tpm",              libxl_defbool),
     ("virtio_pci_hosts", Array(libxl_virtio_pci_host, "num_virtio_pci_hosts")),
+    ("arm_sci",          libxl_arm_sci_type),
     ("u", KeyedUnion(None, libxl_domain_type, "type",
                 [("hvm", Struct(None, [("firmware",         string),
                                        ("bios",             libxl_bios_type),

--- a/tools/xl/xl_parse.c
+++ b/tools/xl/xl_parse.c
@@ -3285,6 +3285,15 @@ skip_usbdev:
         }
     }
 
+    if (!xlu_cfg_get_string (config, "arm_sci", &buf, 1)) {
+        e = libxl_arm_sci_type_from_string(buf, &b_info->arm_sci);
+        if (e) {
+            fprintf(stderr,
+                    "Unknown arm_sci \"%s\" specified\n", buf);
+            exit(-ERROR_FAIL);
+        }
+    }
+
     parse_vkb_list(config, d_config);
     parse_vgsx_list(config, d_config);
     parse_vcamera_list(config, d_config);

--- a/xen/arch/arm/Kconfig
+++ b/xen/arch/arm/Kconfig
@@ -96,6 +96,22 @@ config DOM0LESS_BOOT
 	  Xen boot without the need of a control domain (Dom0), which could be
 	  present anyway.
 
+config HOST_DTB_EXPORT
+	bool "Export host device tree to hypfs if enabled"
+	depends on ARM && HYPFS && !ACPI
+	---help---
+
+	  Export host device-tree to hypfs so toolstack can have an access for the
+	  host device tree from Dom0. If you unsure say N.
+
+config HOST_DTB_MAX_SIZE
+	int "Max host dtb export size"
+	depends on HOST_DTB_EXPORT
+	default 8192
+	---help---
+
+	  Maximum size of the host device-tree exported to hypfs.
+
 config GICV3
 	bool "GICv3 driver"
 	depends on !NEW_VGIC

--- a/xen/arch/arm/Makefile
+++ b/xen/arch/arm/Makefile
@@ -22,6 +22,7 @@ obj-y += domain.o
 obj-y += domain_build.init.o
 obj-$(CONFIG_ARCH_MAP_DOMAIN_PAGE) += domain_page.o
 obj-y += domctl.o
+obj-$(CONFIG_HOST_DTB_EXPORT) += host_dtb_export.o
 obj-$(CONFIG_EARLY_PRINTK) += early_printk.o
 obj-y += efi/
 obj-y += gic.o

--- a/xen/arch/arm/host_dtb_export.c
+++ b/xen/arch/arm/host_dtb_export.c
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Export host FDT to the hypfs
+ *
+ * Copyright (C) 2024 EPAM Systems
+ */
+
+#include <xen/device_tree.h>
+#include <xen/hypfs.h>
+#include <xen/init.h>
+#include <xen/libfdt/libfdt.h>
+
+static HYPFS_VARSIZE_INIT(dt_prop, XEN_HYPFS_TYPE_BLOB,
+        "devicetree", CONFIG_HOST_DTB_MAX_SIZE,
+        &hypfs_leaf_ro_funcs);
+
+static int __init host_dtb_export_init(void)
+{
+    ASSERT(dt_host && (dt_host->sibling == NULL));
+
+    dt_prop.u.content = device_tree_flattened;
+    dt_prop.e.size = fdt_totalsize(device_tree_flattened);
+    hypfs_add_leaf(&hypfs_root, &dt_prop, true);
+
+    return 0;
+}
+
+__initcall(host_dtb_export_init);

--- a/xen/drivers/passthrough/arm/scmi_dt_maker.c
+++ b/xen/drivers/passthrough/arm/scmi_dt_maker.c
@@ -311,3 +311,16 @@ err:
     clean_handles();
     return rc;
 }
+
+int __init scmi_dt_set_phandle(struct kernel_info *kinfo,
+        const char *name)
+{
+    int offset = fdt_path_offset(kinfo->fdt, name);
+    __be32 val = cpu_to_be32(kinfo->phandle_sci_shmem);
+
+    if ( !offset )
+        return -ENODEV;
+
+    return fdt_setprop_inplace(kinfo->fdt, offset, "shmem",
+            &val,sizeof(val));
+}

--- a/xen/drivers/passthrough/arm/scmi_dt_maker.c
+++ b/xen/drivers/passthrough/arm/scmi_dt_maker.c
@@ -25,7 +25,7 @@ struct scmi_phandle {
 
 LIST_HEAD(scmi_ph_list);
 
- int __init scmi_dt_make_shmem_node(struct kernel_info *kinfo)
+int __init scmi_dt_make_shmem_node(struct kernel_info *kinfo)
 {
     int res;
     void *fdt = kinfo->fdt;

--- a/xen/drivers/passthrough/device_tree.c
+++ b/xen/drivers/passthrough/device_tree.c
@@ -15,6 +15,7 @@
  * GNU General Public License for more details.
  */
 
+#include <xen/access_controller.h>
 #include <xen/device_tree.h>
 #include <xen/guest_access.h>
 #include <xen/iommu.h>
@@ -317,6 +318,10 @@ int iommu_do_dt_domctl(struct xen_domctl *domctl, struct domain *d,
                    dt_node_full_name(dev));
             break;
         }
+
+        ret = ac_assign_dt_device(dev, d);
+        if ( ret < 0 )
+            return ret;
 
         ret = iommu_assign_dt_device(d, dev);
 

--- a/xen/include/public/arch-arm.h
+++ b/xen/include/public/arch-arm.h
@@ -467,12 +467,13 @@ typedef uint64_t xen_callback_t;
 #define GUEST_ACPI_BASE xen_mk_ullong(0x20000000)
 #define GUEST_ACPI_SIZE xen_mk_ullong(0x02000000)
 
-/* SCI mediator size */
-#define GUEST_SCI_SHMEM_SIZE   xen_mk_ullong(0x01000)
-
 /* PL011 mappings */
 #define GUEST_PL011_BASE    xen_mk_ullong(0x22000000)
 #define GUEST_PL011_SIZE    xen_mk_ullong(0x00001000)
+
+/* SCI mediator */
+#define GUEST_SCI_SHMEM_BASE xen_mk_ullong(0x22001000)
+#define GUEST_SCI_SHMEM_SIZE xen_mk_ullong(0x01000)
 
 /* Guest PCI-PCIe memory space where config space and BAR will be available.*/
 #define GUEST_VPCI_ADDR_TYPE_MEM            xen_mk_ullong(0x02000000)

--- a/xen/include/public/domctl.h
+++ b/xen/include/public/domctl.h
@@ -1187,6 +1187,13 @@ struct xen_domctl_vmtrace_op {
 #define XEN_DOMCTL_vmtrace_get_option         5
 #define XEN_DOMCTL_vmtrace_set_option         6
 };
+
+/* XEN_DOMCTL_get_sci_info */
+struct xen_domctl_sci_info {
+    uint64_t paddr;
+    uint32_t func_id;
+};
+
 typedef struct xen_domctl_vmtrace_op xen_domctl_vmtrace_op_t;
 DEFINE_XEN_GUEST_HANDLE(xen_domctl_vmtrace_op_t);
 
@@ -1277,6 +1284,7 @@ struct xen_domctl {
 #define XEN_DOMCTL_vmtrace_op                    84
 #define XEN_DOMCTL_get_paging_mempool_size       85
 #define XEN_DOMCTL_set_paging_mempool_size       86
+#define XEN_DOMCTL_get_sci_info                  87
 #define XEN_DOMCTL_gdbsx_guestmemio            1000
 #define XEN_DOMCTL_gdbsx_pausevcpu             1001
 #define XEN_DOMCTL_gdbsx_unpausevcpu           1002
@@ -1339,6 +1347,7 @@ struct xen_domctl {
         struct xen_domctl_vuart_op          vuart_op;
         struct xen_domctl_vmtrace_op        vmtrace_op;
         struct xen_domctl_paging_mempool    paging_mempool;
+        struct xen_domctl_sci_info          sci_info;
         uint8_t                             pad[128];
     } u;
 };

--- a/xen/include/xen/scmi_dt_maker.h
+++ b/xen/include/xen/scmi_dt_maker.h
@@ -16,10 +16,13 @@ int __init scmi_dt_make_shmem_node(struct kernel_info *kinfo);
 int __init scmi_dt_create_node(struct kernel_info *kinfo);
 int __init scmi_dt_scan_node(struct kernel_info *kinfo, void *pfdt,
                              int nodeoff);
+int __init scmi_dt_set_phandle(struct kernel_info *kinfo,
+                               const char *name);
 #else
 #define scmi_dt_make_shmem_node(kinfo)          (0)
 #define scmi_dt_create_node(kinfo)              (0)
 #define scmi_dt_scan_node(kinfo, pfdt, nodeoff) (0)
+#define scmi_dt_set_phandle(kinfo, name)        (0)
 
 #endif /* CONFIG_SCMI_SMC */
 


### PR DESCRIPTION
This feature is adding SCMI mediator support for DomU. Since toolstack is not using in current rpi5 setup - there is no posibility to test it on rpi5. But this approach was tested on R-Car Gen3 board which is using toolstack to start the Domains.
This pr was made to make SCMI-Mediator support generic.

Config parameters needed to enable scmi feature:
```
CONFIG_ARM_SCI=y                                                                
CONFIG_SCMI_SMC=y                                                               
CONFIG_HOST_DTB_EXPORT=y                                                        
CONFIG_ACCESS_CONTROLLER=y 
```

DomU configuration:
```
arm_sci="scmi_smc"
```

DomU partial dtb:
```
/{
      firmware {
            scmi {
                  scmi_reset:protocol@16 {
                  };
                  scmi_pinctrl:protocol@19 {
                               mux1: mux1 {
                               };
                               mux2: mux2 {
                               };
                  };
      };
      passthrough {
         dev1 {
               resets = <&scmi_reset 1>;
               pinctrl-0 = <&mux1>;
         };
         dev2 {
               pinctrl-0 = <&mux2>;
         };
      };
};
 ```
TODO:
- after review make a PR to xen-4.19-xt
Postponed:
- add new syscall to flask.