### PR TITLE
 arm: dom0less: add TEE support

### DIFF
--- a/xen/arch/arm/include/asm/kernel.h
+++ b/xen/arch/arm/include/asm/kernel.h
@@ -57,6 +57,9 @@ struct kernel_info {
     /* Enable pl011 emulation */
     bool vpl011;
 
+    /* TEE type */
+    uint16_t tee_type;
+
     /* Enable/Disable PV drivers interfaces */
     uint16_t dom0less_feature;
 


### PR DESCRIPTION
Allow to provide TEE type for a Dom0less guest via "xen,tee"
property. Create appropriate nodes in the guests' device tree and
initialize tee subsystem for it.

This PR is on top of the following PR:
https://github.com/xen-troops/xen/pull/213
and including commits from it. It is expected to be merged after merging PR mentioned above.