### PR TITLE
sci: scmi_smc: handle SCMI_NOT_SUPPORTED in scmi_relinquish_resources()

### DIFF
--- a/xen/arch/arm/sci/scmi_smc.c
+++ b/xen/arch/arm/sci/scmi_smc.c
@@ -764,8 +764,8 @@ static int scmi_relinquish_resources(struct domain *d)
     tx.flags = 0;
 
     ret = do_smc_xfer(channel, &hdr, &tx, sizeof(tx), NULL, 0);
-    if ( ret )
-        return ret;
+    if ( ret == -EOPNOTSUPP )
+        return 0;
 
     return ret;
 }


### PR DESCRIPTION
The SCMI_BASE_RESET_AGENT_CONFIGURATION may not be supported by TF-A even multi-agent support is enabled, so handle this case and do not fail.