### PR TITLE
vpci: fix build with PCI_PASSTHROUGH/VIRTIO_PCI off

### DIFF
--- a/xen/arch/arm/include/asm/domain.h
+++ b/xen/arch/arm/include/asm/domain.h
@@ -307,7 +307,11 @@ static inline void arch_vcpu_block(struct vcpu *v) {}
 
 #define arch_vm_assist_valid_mask(d) (1UL << VMASST_TYPE_runstate_update_flag)
 
+#ifdef CONFIG_HAS_VPCI
 #define has_vpci(d) ( true )
+#else
+#define has_vpci(d) ( false )
+#endif
 
 struct arch_vcpu_io {
     struct instr_details dabt_instr; /* when the instruction is decoded */

--- a/xen/arch/arm/include/asm/pci.h
+++ b/xen/arch/arm/include/asm/pci.h
@@ -150,8 +150,6 @@ pci_msi_conf_write_intercept(struct pci_dev *pdev, unsigned int reg,
 
 #else   /*!CONFIG_HAS_PCI*/
 
-struct arch_pci_dev { };
-
 static inline bool is_pci_scan_enabled(void)
 {
     return false;

--- a/xen/include/xen/vpci.h
+++ b/xen/include/xen/vpci.h
@@ -335,6 +335,8 @@ static inline bool __must_check vpci_process_pending(struct vcpu *v)
 #ifdef CONFIG_HAS_VPCI_GUEST_SUPPORT
 bool vpci_translate_virtual_device(const struct domain *d, pci_sbdf_t *sbdf);
 #else
+#include <asm/pci.h>
+
 static inline bool vpci_translate_virtual_device(const struct domain *d,
                                                  pci_sbdf_t *sbdf)
 {


### PR DESCRIPTION
Fix build with CONFIG_PCI_PASSTHROUGH/VIRTIO_PCI off.

Pretty brutal fixes. Tested.