### PR TITLE
ARM_SCI agent id configuration and Dom0's iomem permission fix

### DIFF
--- a/docs/man/xl.cfg.5.pod.in
+++ b/docs/man/xl.cfg.5.pod.in
@@ -1723,10 +1723,20 @@ Specifies OS ID.
 
 =back
 
-=item B<arm_sci="STRING">
+=item B<arm_sci="ARM_SCI_STRING">
 
-B<Arm only> Set ARM_SCI type for the guest. ARM_SCI is System Control Protocol
-allows domain to manage various functions that are provided by HW platform.
+B<Arm only> Set ARM_SCI specific options for the guest. ARM_SCI is System
+Control Protocol allows domain to manage various functions that are provided
+by HW platform.
+
+B<ARM_SCI_STRING> is a comma separated list of C<KEY=VALUE> settings,
+from the following list:
+
+=over 4
+
+=item B<type=STRING>
+
+Specifies an ARM_SCI type for the guest.
 
 =over 4
 
@@ -1744,6 +1754,12 @@ clocks, power-domains and resets between Domains and ATF. Disabled by default.
 SCP is used as transport.
 
 =back
+
+=item B<agent_id=NUMBER>
+
+Specifies a non-zero ARM_SCI agent id for the guest. This option is mandatory
+if the SCMI_SMC support is enabled for the guest. The agent ids of domains
+existing on a single host must be unique.
 
 =back
 

--- a/docs/misc/xen-command-line.pandoc
+++ b/docs/misc/xen-command-line.pandoc
@@ -1191,6 +1191,13 @@ Extended regions are ranges of unused address space exposed to the guest
 as "safe to use" for special memory mappings. Disable if your board
 device tree is incomplete.
 
+### dom0_sci_agent_id (Arm)
+> `= <integer>`
+
+Since the SCMI_SMC support is always enabled for the Dom0 if available,
+this option specifies a non-zero ARM_SCI agent id for the Dom0. The agent ids
+of domains existing on a single host must be unique.
+
 ### flask
 > `= permissive | enforcing | late | disabled`
 

--- a/tools/libs/light/libxl_arm.c
+++ b/tools/libs/light/libxl_arm.c
@@ -360,7 +360,7 @@ int libxl__arch_domain_prepare_config(libxl__gc *gc,
     if (d_config->num_pcidevs)
         config->arch.pci_flags = XEN_DOMCTL_CONFIG_PCI_VPCI;
 
-    switch (d_config->b_info.arm_sci) {
+    switch (d_config->b_info.arm_sci.type) {
     case LIBXL_ARM_SCI_TYPE_NONE:
         config->arch.arm_sci_type = XEN_DOMCTL_CONFIG_ARM_SCI_NONE;
         break;
@@ -369,9 +369,10 @@ int libxl__arch_domain_prepare_config(libxl__gc *gc,
         break;
     default:
         LOG(ERROR, "Unknown ARM_SCI type %d",
-            d_config->b_info.arm_sci);
+            d_config->b_info.arm_sci.type);
         return ERROR_FAIL;
     }
+    config->arch.arm_sci_agent_id = d_config->b_info.arm_sci.agent_id;
 
     return 0;
 }
@@ -2073,10 +2074,10 @@ next_resize:
         if (info->arch_arm.vuart == LIBXL_VUART_TYPE_SBSA_UART)
             FDT( make_vpl011_uart_node(gc, fdt, ainfo, dom) );
 
-        if (info->arm_sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC)
+        if (info->arm_sci.type == LIBXL_ARM_SCI_TYPE_SCMI_SMC)
             FDT( scmi_dt_make_shmem_node(gc, fdt) );
 
-        FDT( make_firmware_node(gc, fdt, pfdt, info->tee, info->arm_sci,
+        FDT( make_firmware_node(gc, fdt, pfdt, info->tee, info->arm_sci.type,
                 state->arm_sci_agent_funcid) );
 
         if (d_config->num_pcidevs)
@@ -2375,7 +2376,7 @@ int libxl__arch_build_dom_finish(libxl__gc *gc,
         }
     }
 
-    if (info->arm_sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
+    if (info->arm_sci.type == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
         ret = map_sci_page(gc, dom->guest_domid, state->arm_sci_agent_paddr,
                            GUEST_SCI_SHMEM_BASE);
         if (ret < 0) {

--- a/tools/libs/light/libxl_create.c
+++ b/tools/libs/light/libxl_create.c
@@ -774,7 +774,7 @@ int libxl__domain_make(libxl__gc *gc, libxl_domain_config *d_config,
      */
     assert(libxl_domid_valid_guest(*domid));
 
-    if (d_config->b_info.arm_sci == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
+    if (d_config->b_info.arm_sci.type == LIBXL_ARM_SCI_TYPE_SCMI_SMC) {
         ret = xc_domain_get_sci_info(ctx->xch, *domid, &state->arm_sci_agent_paddr,
                 &state->arm_sci_agent_funcid);
         LOGD(DEBUG, *domid,"sci_agent_paddr = %lx", state->arm_sci_agent_paddr);

--- a/tools/libs/light/libxl_types.idl
+++ b/tools/libs/light/libxl_types.idl
@@ -565,6 +565,11 @@ libxl_arm_sci_type = Enumeration("arm_sci_type", [
     (1, "scmi_smc")
     ], init_val = "LIBXL_ARM_SCI_TYPE_NONE")
 
+libxl_arm_sci = Struct("arm_sci", [
+    ("type", libxl_arm_sci_type),
+    ("agent_id", uint8)
+    ])
+
 libxl_rdm_reserve = Struct("rdm_reserve", [
     ("strategy",    libxl_rdm_reserve_strategy),
     ("policy",      libxl_rdm_reserve_policy),
@@ -668,7 +673,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
     ("tee",              libxl_tee_type),
     ("tpm",              libxl_defbool),
     ("virtio_pci_hosts", Array(libxl_virtio_pci_host, "num_virtio_pci_hosts")),
-    ("arm_sci",          libxl_arm_sci_type),
+    ("arm_sci",          libxl_arm_sci),
     ("u", KeyedUnion(None, libxl_domain_type, "type",
                 [("hvm", Struct(None, [("firmware",         string),
                                        ("bios",             libxl_bios_type),

--- a/tools/xl/xl_parse.c
+++ b/tools/xl/xl_parse.c
@@ -1635,6 +1635,83 @@ static void parse_vcamera_list(const XLU_Config *config,
     }
 }
 
+static int parse_arm_sci_config(XLU_Config *cfg, libxl_arm_sci *arm_sci,
+                                const char *str)
+{
+#define STATE_OPTION   0
+#define STATE_TYPE     1
+#define STATE_AGENT_ID 2
+#define STATE_TERMINAL 3
+
+    int ret, state = STATE_OPTION;
+    char *buf2, *tok, *ptr, *end;
+
+    if (NULL == (buf2 = ptr = strdup(str)))
+        return ERROR_NOMEM;
+
+    for (tok = ptr, end = ptr + strlen(ptr) + 1; ptr < end; ptr++) {
+        switch(state) {
+        case STATE_OPTION:
+            if (*ptr == '=') {
+                *ptr = '\0';
+                if (!strcmp(tok, "type")) {
+                    state = STATE_TYPE;
+                } else if (!strcmp(tok, "agent_id")) {
+                    state = STATE_AGENT_ID;
+                } else {
+                    fprintf(stderr, "Unknown ARM_SCI option: %s\n", tok);
+                    goto parse_error;
+                }
+                tok = ptr + 1;
+            }
+            break;
+        case STATE_TYPE:
+            if (*ptr == '\0' || *ptr == ',') {
+                state = *ptr == ',' ? STATE_OPTION : STATE_TERMINAL;
+                *ptr = '\0';
+                ret = libxl_arm_sci_type_from_string(tok, &arm_sci->type);
+                if (ret) {
+                    fprintf(stderr, "Unknown ARM_SCI type: %s\n", tok);
+                    goto parse_error;
+                }
+                tok = ptr + 1;
+            }
+            break;
+        case STATE_AGENT_ID:
+            if (*ptr == ',' || *ptr == '\0') {
+                state = *ptr == ',' ? STATE_OPTION : STATE_TERMINAL;
+                *ptr = '\0';
+                arm_sci->agent_id = strtoul(tok, NULL, 0);
+                tok = ptr + 1;
+            }
+        default:
+            break;
+        }
+    }
+
+    if (arm_sci->type == LIBXL_ARM_SCI_TYPE_SCMI_SMC &&
+        arm_sci->agent_id == 0) {
+        fprintf(stderr, "A non-zero ARM_SCI agent_id must be specified\n");
+        goto parse_error;
+    }
+
+    if (tok != ptr || state != STATE_TERMINAL)
+        goto parse_error;
+
+    free(buf2);
+
+    return 0;
+
+parse_error:
+    free(buf2);
+    return ERROR_INVAL;
+
+#undef STATE_OPTION
+#undef STATE_TYPE
+#undef STATE_AGENT_ID
+#undef STATE_TERMINAL
+}
+
 void parse_config_data(const char *config_source,
                        const char *config_data,
                        int config_len,
@@ -3310,13 +3387,13 @@ skip_usbdev:
     else
         b_info->arch_arm.rproc = -1;
 
-    if (!xlu_cfg_get_string (config, "arm_sci", &buf, 1)) {
-        e = libxl_arm_sci_type_from_string(buf, &b_info->arm_sci);
-        if (e) {
-            fprintf(stderr,
-                    "Unknown arm_sci \"%s\" specified\n", buf);
-            exit(-ERROR_FAIL);
-        }
+    if (!xlu_cfg_get_string(config, "arm_sci", &buf, 1)) {
+        libxl_arm_sci arm_sci = { 0 };
+        if (!parse_arm_sci_config(config, &arm_sci, buf)) {
+            b_info->arm_sci.type = arm_sci.type;
+            b_info->arm_sci.agent_id = arm_sci.agent_id;
+        } else
+            exit(EXIT_FAILURE);
     }
 
     parse_vkb_list(config, d_config);

--- a/xen/arch/arm/dom0less-build.c
+++ b/xen/arch/arm/dom0less-build.c
@@ -889,9 +889,6 @@ static int __init construct_domU(struct domain *d,
 #ifdef CONFIG_TEE
     const char *tee;
 #endif
-#ifdef CONFIG_ARM_SCI
-    const char *arm_sci;
-#endif
     int rc;
     u64 mem;
     u32 p2m_mem_mb;
@@ -934,26 +931,6 @@ static int __init construct_domU(struct domain *d,
     }
     else if ( rc == 0 && !strcmp(dom0less_enhanced, "no-xenstore") )
         kinfo.dom0less_feature = DOM0LESS_ENHANCED_NO_XS;
-
-#ifdef CONFIG_ARM_SCI
-    rc = dt_property_read_string(node, "xen,arm_sci", &arm_sci);
-    if ( rc == -EILSEQ ||
-         rc == -ENODATA ||
-         (rc == 0 && !strcmp(arm_sci, "none")) )
-    {
-        if ( !hardware_domain )
-            kinfo.sci_type = XEN_DOMCTL_CONFIG_ARM_SCI_NONE;
-    }
-    else if ( rc == 0 && !strcmp(arm_sci, "scmi_smc") )
-        kinfo.sci_type = XEN_DOMCTL_CONFIG_ARM_SCI_SCMI_SMC;
-#endif
-
-    if (kinfo.sci_type != XEN_DOMCTL_CONFIG_ARM_SCI_NONE)
-    {
-        rc = sci_domain_init(d, kinfo.sci_type, NULL);
-        if ( rc < 0 )
-            return rc;
-    }
 
 #ifdef CONFIG_TEE
     rc = dt_property_read_string(node, "xen,tee", &tee);
@@ -1199,6 +1176,14 @@ void __init create_domUs(void)
             panic("'sve' property found, but CONFIG_ARM64_SVE not selected\n");
 #endif
         }
+
+        /*
+         * XXX We will need to retrieve the values from the device tree here
+         * and fill in these fields. Always disable ARM_SCI in case of Dom0less
+         * for now.
+         */
+        d_cfg.arch.arm_sci_type = XEN_DOMCTL_CONFIG_ARM_SCI_NONE;
+        d_cfg.arch.arm_sci_agent_id = 0;
 
         /*
          * The variable max_init_domid is initialized with zero, so here it's

--- a/xen/arch/arm/domain.c
+++ b/xen/arch/arm/domain.c
@@ -701,6 +701,12 @@ int arch_sanitise_domain_config(struct xen_domctl_createdomain *config)
         dprintk(XENLOG_INFO, "Unsupported ARM_SCI type\n");
         return -EINVAL;
     }
+    else if ( config->arch.arm_sci_type == XEN_DOMCTL_CONFIG_ARM_SCI_SCMI_SMC &&
+              config->arch.arm_sci_agent_id == 0 )
+    {
+        dprintk(XENLOG_INFO, "A non-zero ARM_SCI agent_id must be specified\n");
+        return -EINVAL;
+    }
 
     return 0;
 }
@@ -785,12 +791,6 @@ int arch_domain_create(struct domain *d,
         /* At this stage vgic_reserve_virq should never fail */
         if ( !vgic_reserve_virq(d, GUEST_EVTCHN_PPI) )
             BUG();
-        if ( config->arch.arm_sci_type != XEN_DOMCTL_CONFIG_ARM_SCI_NONE )
-        {
-            if ( (rc = sci_domain_init(d, config->arch.arm_sci_type,
-                                        &config->arch)) != 0)
-                goto fail;
-        }
     }
 
     /*
@@ -805,6 +805,10 @@ int arch_domain_create(struct domain *d,
     /* Copy the encoded vector length sve_vl from the domain configuration */
     d->arch.sve_vl = config->arch.sve_vl;
 #endif
+
+    if ( (rc = sci_domain_init(d, config->arch.arm_sci_type,
+                               &config->arch)) != 0 )
+        goto fail;
 
     d->arch.vgsx_osid = config->arch.vgsx_osid;
 

--- a/xen/arch/arm/domain_build.c
+++ b/xen/arch/arm/domain_build.c
@@ -2148,12 +2148,6 @@ static int __init construct_dom0(struct domain *d)
     if ( rc < 0 )
         return rc;
 
-#if CONFIG_ARM_SCI
-    rc = sci_domain_init(d, sci_get_type(), NULL);
-    if ( rc < 0 )
-        return rc;
-#endif
-
     if ( acpi_disabled )
     {
         rc = prepare_dtb_hwdom(d, &kinfo);

--- a/xen/arch/arm/domain_build.c
+++ b/xen/arch/arm/domain_build.c
@@ -54,6 +54,9 @@ boolean_param("ext_regions", opt_ext_regions);
 static u64 __initdata dom0_mem;
 static bool __initdata dom0_mem_set;
 
+static uint8_t __initdata opt_dom0_sci_agent_id;
+integer_param("dom0_sci_agent_id", opt_dom0_sci_agent_id);
+
 static int __init parse_dom0_mem(const char *s)
 {
     dom0_mem_set = true;
@@ -2191,6 +2194,13 @@ void __init create_dom0(void)
     dom0_cfg.max_vcpus = dom0_max_vcpus();
 
     dom0_cfg.arch.arm_sci_type = sci_get_type();
+    if ( dom0_cfg.arch.arm_sci_type == XEN_DOMCTL_CONFIG_ARM_SCI_SCMI_SMC &&
+         opt_dom0_sci_agent_id == 0 )
+    {
+        warning_add("WARNING: A non-zero ARM_SCI agent_id must be specified - assuming 1\n");
+        opt_dom0_sci_agent_id = 1;
+    }
+    dom0_cfg.arch.arm_sci_agent_id = opt_dom0_sci_agent_id;
 
     if ( iommu_enabled )
         dom0_cfg.flags |= XEN_DOMCTL_CDF_iommu;

--- a/xen/arch/arm/sci/scmi_smc.c
+++ b/xen/arch/arm/sci/scmi_smc.c
@@ -738,6 +738,21 @@ static int scmi_domain_init(struct domain *d,
     d->arch.sci_channel.paddr = channel->paddr;
     d->arch.sci_channel.guest_func_id = scmi_data.func_id;
 
+    /*
+     * Dom0 (if present) needs to have an access to the guest memory range
+     * to satisfy iomem_access_permitted() check in XEN_DOMCTL_iomem_permission
+     * domctl.
+     */
+    if ( hardware_domain && !is_hardware_domain(d) )
+    {
+        int res;
+
+        res = iomem_permit_access(hardware_domain, paddr_to_pfn(channel->paddr),
+                                  paddr_to_pfn(channel->paddr + PAGE_SIZE - 1));
+        if ( res )
+            return res;
+    }
+
     return 0;
 }
 

--- a/xen/arch/arm/sci/scmi_smc.c
+++ b/xen/arch/arm/sci/scmi_smc.c
@@ -85,7 +85,7 @@ struct scmi_shared_mem {
 };
 
 struct scmi_channel {
-    int agent_id;
+    uint32_t agent_id;
     uint32_t func_id;
     domid_t domain_id;
     uint64_t paddr;
@@ -354,7 +354,7 @@ clean:
     return ret;
 }
 
-static struct scmi_channel *get_channel_by_id(uint8_t agent_id)
+static struct scmi_channel *get_channel_by_id(uint32_t agent_id)
 {
     struct scmi_channel *curr;
     bool found = false;
@@ -376,19 +376,24 @@ static struct scmi_channel *get_channel_by_id(uint8_t agent_id)
     return NULL;
 }
 
-static struct scmi_channel *aquire_scmi_channel(domid_t domain_id)
+static struct scmi_channel *aquire_scmi_channel(struct domain *d,
+                                                uint32_t agent_id)
 {
     struct scmi_channel *curr;
-    struct scmi_channel *ret = NULL;
-
-    ASSERT(domain_id != DOMID_INVALID && domain_id >= 0);
+    struct scmi_channel *ret = ERR_PTR(-ENOENT);
 
     spin_lock(&scmi_data.channel_list_lock);
     list_for_each_entry(curr, &scmi_data.channel_list, list)
     {
-        if ( curr->domain_id == DOMID_INVALID )
+        if ( curr->agent_id == agent_id )
         {
-            curr->domain_id = domain_id;
+            if ( curr->domain_id != DOMID_INVALID )
+            {
+                ret = ERR_PTR(-EEXIST);
+                break;
+            }
+
+            curr->domain_id = d->domain_id;
             ret = curr;
             break;
         }
@@ -429,7 +434,7 @@ static void unmap_channel_memory(struct scmi_channel *channel)
     channel->shmem = NULL;
 }
 
-static struct scmi_channel *smc_create_channel(uint8_t agent_id,
+static struct scmi_channel *smc_create_channel(uint32_t agent_id,
                                                uint32_t func_id, uint64_t addr)
 {
     struct scmi_channel *channel;
@@ -717,9 +722,13 @@ static int scmi_domain_init(struct domain *d,
     if ( !scmi_data.initialized )
         return 0;
 
-    channel = aquire_scmi_channel(d->domain_id);
-    if ( IS_ERR_OR_NULL(channel) )
-        return -ENOENT;
+    channel = aquire_scmi_channel(d, config->arm_sci_agent_id);
+    if ( IS_ERR(channel) )
+    {
+        printk(XENLOG_ERR"scmi: Failed to aquire SCMI channel for agent_id %u: %ld\n",
+               config->arm_sci_agent_id, PTR_ERR(channel));
+        return PTR_ERR(channel);
+    }
 
     printk(XENLOG_INFO
            "scmi: Aquire SCMI channel id = 0x%x , domain_id = %d paddr = 0x%lx\n",

--- a/xen/include/public/arch-arm.h
+++ b/xen/include/public/arch-arm.h
@@ -342,6 +342,8 @@ struct xen_arch_domainconfig {
     /* IN */
     uint16_t arm_sci_type;
     /* IN */
+    uint8_t arm_sci_agent_id;
+    /* IN */
     uint32_t nr_spis;
     /*
      * IN


### PR DESCRIPTION
With that, it is possible to configure ARM_SCI agent ids for both Dom0 and usual DomUs. Refer to the documentation (corresponding commits have links) how to specify required values. The Dom0less DomUs are not covered by this PR.

For any domain, any valid free agent id can be specified.
@GrygiriiS @rshym 