### PR TITLE
Xen 4.19 xt0.2 v4h demo fix msi

### DIFF
--- a/xen/arch/arm/Kconfig
+++ b/xen/arch/arm/Kconfig
@@ -247,6 +247,7 @@ config PCI_PASSTHROUGH
 	select HAS_PCI
 	select HAS_VPCI
 	select HAS_VPCI_GUEST_SUPPORT
+	select HAS_PCI_MSI
 	default n
 	help
 	  This option enables PCI device passthrough

--- a/xen/arch/arm/include/asm/msi.h
+++ b/xen/arch/arm/include/asm/msi.h
@@ -10,8 +10,13 @@ struct arch_msix {
     spinlock_t table_lock;
 };
 
+struct msi_info {
+    pci_sbdf_t sbdf;
+};
+
 struct msi_desc {
     struct list_head list;
+    struct pci_dev *dev;
     int irq;
 };
 

--- a/xen/arch/arm/include/asm/msi.h
+++ b/xen/arch/arm/include/asm/msi.h
@@ -1,0 +1,18 @@
+#ifndef __ASM_MSI_H
+#define __ASM_MSI_H
+
+static inline int pci_reset_msix_state(struct pci_dev *pdev) { return 0; }
+static inline void msixtbl_init(struct domain *d) {}
+static inline void pci_cleanup_msi(struct pci_dev *pdev) {}
+
+struct arch_msix {
+    unsigned int nr_entries;
+    spinlock_t table_lock;
+};
+
+struct msi_desc {
+    struct list_head list;
+    int irq;
+};
+
+#endif

--- a/xen/drivers/passthrough/msi.c
+++ b/xen/drivers/passthrough/msi.c
@@ -1,7 +1,9 @@
 #include <xen/init.h>
 #include <xen/pci.h>
 #include <xen/msi.h>
+#ifdef CONFIG_X86
 #include <asm/hvm/io.h>
+#endif
 
 int pdev_msix_assign(struct domain *d, struct pci_dev *pdev)
 {

--- a/xen/drivers/vpci/arm_vmsi.c
+++ b/xen/drivers/vpci/arm_vmsi.c
@@ -88,8 +88,9 @@ void vpci_msi_arch_mask(struct vpci_msi *msi, const struct pci_dev *pdev,
 {
     unsigned int pos = pci_find_cap_offset(pdev->sbdf, PCI_CAP_ID_MSI);
 
-    pci_conf_write32(pdev->sbdf, msi->mask,
-                     msi_mask_bits_reg(pos,pdev->vpci->msi->address64));
+    pci_conf_write32(pdev->sbdf,
+                     msi_mask_bits_reg(pos, pdev->vpci->msi->address64),
+                     msi->mask);
 }
 
 int vpci_msix_arch_disable_entry(struct vpci_msix_entry *entry,

--- a/xen/drivers/vpci/msi.c
+++ b/xen/drivers/vpci/msi.c
@@ -172,19 +172,10 @@ static void cf_check mask_write(
     if ( !dmask )
         return;
 
-    if ( msi->enabled )
-    {
-        unsigned int i;
-
-        for ( i = ffs(dmask) - 1; dmask && i < msi->vectors;
-              i = ffs(dmask) - 1 )
-        {
-            vpci_msi_arch_mask(msi, pdev, i, (val >> i) & 1);
-            __clear_bit(i, &dmask);
-        }
-    }
-
     msi->mask = val;
+
+    if ( msi->enabled )
+        vpci_msi_arch_mask(msi, pdev, 0, true);
 }
 
 static int cf_check init_msi(struct pci_dev *pdev)


### PR DESCRIPTION
In the case VPCI device supports only MSI and not MSI-X it's observed that MSI IRQ are not setup properly in DomU.
This series fixes VPCI MSI IRQs in DomU.

@otyshchenko1 @lorc @Deedone 