### PR TITLE
arm: vgic: initialize eSPI rank's indexes with proper values

### DIFF
--- a/xen/arch/arm/vgic-v3.c
+++ b/xen/arch/arm/vgic-v3.c
@@ -953,7 +953,7 @@ static int __vgic_v3_distr_common_mmio_write(const char *name, struct vcpu *v,
         vgic_lock_rank(v, rank, flags);
         tr = rank->ienable;
         vreg_reg32_setbits(&rank->ienable, r, info);
-        vgic_enable_irqs(v, (rank->ienable) & (~tr), EXT_RANK_IDX2NUM(rank->index));
+        vgic_enable_irqs(v, (rank->ienable) & (~tr), rank->index);
         vgic_unlock_rank(v, rank, flags);
         return 1;
 
@@ -964,7 +964,7 @@ static int __vgic_v3_distr_common_mmio_write(const char *name, struct vcpu *v,
         vgic_lock_rank(v, rank, flags);
         tr = rank->ienable;
         vreg_reg32_clearbits(&rank->ienable, r, info);
-        vgic_disable_irqs(v, (~rank->ienable) & tr, EXT_RANK_IDX2NUM(rank->index));
+        vgic_disable_irqs(v, (~rank->ienable) & tr, rank->index);
         vgic_unlock_rank(v, rank, flags);
         return 1;
 

--- a/xen/arch/arm/vgic.c
+++ b/xen/arch/arm/vgic.c
@@ -142,7 +142,7 @@ static int init_vgic_espi(struct domain *d)
         vgic_init_pending_irq(&d->arch.vgic.pending_irqs[i + d->arch.vgic.nr_spis], ESPI_IDX2INTID(i));
 
     for ( i = 0; i < DOMAIN_NR_EXT_RANKS(d); i++ )
-        vgic_rank_init(&d->arch.vgic.ext_shared_irqs[i], i, 0);
+        vgic_rank_init(&d->arch.vgic.ext_shared_irqs[i], EXT_RANK_IDX2NUM(i), 0);
 
     return 0;
 }


### PR DESCRIPTION
Currently, indexes for eSPI ranks start from 0 to 31, and then, to get the IRQ index for eSPIs, we need to add EXT_RANK_MIN, which is 128. Using EXT_RANK_IDX2NUM macro in multiple places leads to code complexity, so now, for pending IRQs and inflight IRQs, this eSPI offset is not added. It is better to initialize properly rank indexes on vgic init and, as a result, fix missing conversions, simplify the code, and get rid of redundant runtime calculations. Such a fix is already present in mainline Xen, introduced during code review.