### PR TITLE
Revert legacy gsx code

### DIFF
--- a/tools/libs/light/libxl_arm.c
+++ b/tools/libs/light/libxl_arm.c
@@ -343,14 +343,6 @@ int libxl__arch_domain_prepare_config(libxl__gc *gc,
         config->arch.sve_vl = d_config->b_info.arch_arm.sve_vl / 128U;
     }
 
-    if (d_config->num_vgsxs) {
-        libxl_device_vgsx *vgsx;
-
-        vgsx = &d_config->vgsxs[0];
-        config->arch.vgsx_osid = vgsx->osid;
-    } else
-        config->arch.vgsx_osid = 0;
-
     return 0;
 }
 

--- a/tools/xl/xl_parse.c
+++ b/tools/xl/xl_parse.c
@@ -1322,8 +1322,6 @@ out:
     if (rc) exit(EXIT_FAILURE);
 }
 
-#define GSX_MAX_OS_CNT	8
-
 static int parse_vgsx_config(libxl_device_vgsx *vgsx, char *token)
 {
     char *oparg;
@@ -1332,11 +1330,6 @@ static int parse_vgsx_config(libxl_device_vgsx *vgsx, char *token)
         vgsx->backend_domname = strdup(oparg);
     } else if (MATCH_OPTION("osid", token, oparg)) {
         vgsx->osid = strtoul(oparg, NULL, 0);
-        if (vgsx->osid >= GSX_MAX_OS_CNT) {
-            fprintf(stderr, "Invalid vGSX OSID parameter: %d\n", vgsx->osid);
-            return -1;
-        }
-
     } else {
         fprintf(stderr, "Unknown string \"%s\" in vgsx spec\n", token);
         return -1;

--- a/xen/arch/arm/domain.c
+++ b/xen/arch/arm/domain.c
@@ -785,8 +785,6 @@ int arch_domain_create(struct domain *d,
     d->arch.sve_vl = config->arch.sve_vl;
 #endif
 
-    d->arch.vgsx_osid = config->arch.vgsx_osid;
-
     return 0;
 
 fail:

--- a/xen/arch/arm/include/asm/domain.h
+++ b/xen/arch/arm/include/asm/domain.h
@@ -119,8 +119,6 @@ struct arch_domain
     void *tee;
 #endif
 
-    /* OSID used by virtual GSX device */
-    uint8_t vgsx_osid;
 }  __cacheline_aligned;
 
 struct arch_vcpu

--- a/xen/arch/arm/include/asm/gic.h
+++ b/xen/arch/arm/include/asm/gic.h
@@ -257,7 +257,6 @@ int gic_remove_irq_from_guest(struct domain *d, unsigned int virq,
 extern void gic_clear_pending_irqs(struct vcpu *v);
 
 extern void init_maintenance_interrupt(void);
-extern void init_gsx_interrupt(void);
 extern void gic_raise_guest_irq(struct vcpu *v, unsigned int virtual_irq,
         unsigned int priority);
 extern void gic_raise_inflight_irq(struct vcpu *v, unsigned int virtual_irq);

--- a/xen/arch/arm/irq.c
+++ b/xen/arch/arm/irq.c
@@ -15,10 +15,8 @@
 #include <xen/init.h>
 #include <xen/errno.h>
 #include <xen/sched.h>
-#include <xen/vmap.h>
 #include <xen/param.h>
 
-#include <asm/io.h>
 #include <asm/gic.h>
 #include <asm/vgic.h>
 
@@ -35,46 +33,18 @@ const unsigned int nr_irqs = NR_IRQS;
 static unsigned int local_irqs_type[NR_LOCAL_IRQS];
 static DEFINE_SPINLOCK(local_irqs_type_lock);
 
-/* If true, the GSX IRQ support is enabled for the guests */
-bool opt_rcar3_gsx = true;
-boolean_param("rcar3_gsx", opt_rcar3_gsx);
-
-#define GSX_MAX_OS_CNT                                     8
-#define GSX_REG_BASE_ADDR                         0xfd000000
-#define GSX_REG_BANK_SIZE                            0x10000
-/*
- * Please note:
- * The last 5 Guest OSes are sharing one register. The argument for using
- * the registers this way is that most systems have less than 5 domains.
- * It is preferable to use the entire register for an OS' IRQ counter
- * (rather than fit two counters in one register) to minimize the number
- * of operations involved in triggering and handling an IRQ.
- */
-#define GSX_OS_IRQ_CNT_REGS  {0x2028, 0x2050, 0x2030, 0x2058, \
-                              0x2058, 0x2058, 0x2058, 0x2058}
-#define GSX_IRQ_STATUS_REG                        0x00000ac8
-#define GSX_IRQ_STATUS_EVENT_MASK                 0x00000004
-#define GSX_IRQ_CLEAR_REG                         0x00000ac8
-#define GSX_IRQ_CLEAR_MASK                        0xfffffffb
-
-static void __iomem *gsx_reg_base;
-static void __iomem *gsx_irq_cnt_regs[GSX_MAX_OS_CNT];
 const int gsx_irq_num = 151;
+
+/* Total context count is 8, but the 8th context is always used by host */
+#define GSX_GUESTS_CNT    7
 
 /* Describe an IRQ assigned to a guest */
 struct irq_guest
 {
     struct domain *d;
     unsigned int virq;
+    struct domain *gsx_guests[GSX_GUESTS_CNT];
 };
-
-struct gsx_info
-{
-    struct domain *domains[GSX_MAX_OS_CNT];
-    uint32_t irq_cnts[GSX_MAX_OS_CNT];
-};
-
-static struct gsx_info gsx_info;
 
 static void ack_none(struct irq_desc *irq)
 {
@@ -283,125 +253,74 @@ int request_irq(unsigned int irq, unsigned int irqflags,
     return retval;
 }
 
-void remove_gsx_domain(struct domain *d)
+void remove_gsx_guest(struct domain *d)
 {
     struct irq_desc *desc = irq_to_desc(gsx_irq_num);
-    struct gsx_info *info = desc->action->dev_id;
+    struct irq_guest *info;
     unsigned long flags;
+    int i;
 
     if ( !desc->action )
         return;
 
     spin_lock_irqsave(&desc->lock, flags);
 
-    if ( (d->arch.vgsx_osid < GSX_MAX_OS_CNT) &&
-         (info->domains[d->arch.vgsx_osid] == d) )
-    {
-        info->domains[d->arch.vgsx_osid] = NULL;
+    info = irq_get_guest_info(desc);
 
-        printk(XENLOG_INFO "Removed GSX %pd (OSID %u)\n", d, d->arch.vgsx_osid);
+    /* clear a slot occupied by gsx guest */
+    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
+    {
+        if ( !info->gsx_guests[i] )
+            continue;
+
+        if ( info->gsx_guests[i] == d )
+        {
+            info->gsx_guests[i] = NULL;
+            printk("Removed GSX guest domain %u\n", d->domain_id);
+            break;
+        }
     }
 
     spin_unlock_irqrestore(&desc->lock, flags);
 }
 
 /* called with desc->lock held */
-static int add_gsx_domain(struct domain *d)
+static void add_gsx_guest(struct domain *d, struct irq_guest *info)
 {
-    struct irq_desc *desc = irq_to_desc(gsx_irq_num);
-    struct gsx_info *info = desc->action->dev_id;
-
-    ASSERT(spin_is_locked(&desc->lock));
-
-    if ( (d->arch.vgsx_osid < GSX_MAX_OS_CNT) &&
-         (info->domains[d->arch.vgsx_osid] == NULL) )
-    {
-        info->domains[d->arch.vgsx_osid] = d;
-
-        printk(XENLOG_INFO "Added GSX %pd (OSID %u)\n", d, d->arch.vgsx_osid);
-
-        return 0;
-    }
-
-    printk(XENLOG_ERR "Failed to add GSX %pd (OSID %u)\n", d,
-           d->arch.vgsx_osid);
-
-    return -1;
-}
-
-static void gsx_irq_handler(int irq, void *dev_id, struct cpu_user_regs *regs)
-{
-    struct irq_desc *desc = irq_to_desc(gsx_irq_num);
-    struct gsx_info *info = desc->action->dev_id;
-    uint32_t irq_cnt, irq_status;
-    bool injected = false;
     int i;
 
-    spin_lock_irq(&desc->lock);
-
-    /* Clear irq status to avoid irq to be raised again */
-    irq_status = readl_relaxed(gsx_reg_base + GSX_IRQ_STATUS_REG);
-    if ( irq_status & GSX_IRQ_STATUS_EVENT_MASK )
+    /* find an empty slot to put gsx guest in it */
+    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
     {
-        writel_relaxed(GSX_IRQ_CLEAR_MASK, gsx_reg_base + GSX_IRQ_CLEAR_REG);
+        if ( info->gsx_guests[i] )
+           continue;
 
-        /* Inject irq to required gsx domains */
-        for ( i = 0; i < GSX_MAX_OS_CNT; i++ )
-        {
-            if ( !info->domains[i] )
-                continue;
-
-            irq_cnt = readl_relaxed(gsx_irq_cnt_regs[i]);
-            if ( info->irq_cnts[i] != irq_cnt )
-            {
-                info->irq_cnts[i] = irq_cnt;
-                vgic_inject_irq(info->domains[i], NULL, gsx_irq_num, true);
-                injected = true;
-            }
-        }
+        info->gsx_guests[i] = d;
+        printk("Added GSX guest domain %u\n", d->domain_id);
+        break;
     }
 
-    spin_unlock_irq(&desc->lock);
-
-    if ( !injected && (irq_status & GSX_IRQ_STATUS_EVENT_MASK) )
-        printk(XENLOG_WARNING "Failed to inject GSX IRQ\n");
+    BUG_ON(i == ARRAY_SIZE(info->gsx_guests));
 }
 
-/* TODO GSX platform data (iomem, irq) should be retrieved from dt */
-void init_gsx_interrupt(void)
+/* called with desc->lock held */
+static void init_gsx_guests(struct domain *d, struct irq_guest *info)
 {
-    const uint32_t irq_reg_offset[GSX_MAX_OS_CNT] = GSX_OS_IRQ_CNT_REGS;
-    int i, ret;
+    memset(info->gsx_guests, 0, sizeof(info->gsx_guests));
+}
 
-    if ( !opt_rcar3_gsx )
+/* called with desc->lock held */
+static void inject_to_gsx_guests(struct irq_guest *info)
+{
+    int i;
+
+    /* inject irq to all gsx guests */
+    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
     {
-        printk(XENLOG_INFO "GSX IRQ is disabled\n");
-        return;
+        if ( !info->gsx_guests[i] )
+            continue;
+        vgic_inject_irq(info->gsx_guests[i], NULL, info->virq, true);
     }
-
-    gsx_reg_base = ioremap_nocache(GSX_REG_BASE_ADDR, GSX_REG_BANK_SIZE);
-    if ( !gsx_reg_base )
-    {
-        printk(XENLOG_ERR "Failed to map GSX MMIO range\n");
-        return;
-    }
-
-    for ( i = 0; i < GSX_MAX_OS_CNT; i++ )
-        gsx_irq_cnt_regs[i] = gsx_reg_base + irq_reg_offset[i];
-
-    /* Just to be sure */
-    memset(&gsx_info, 0, sizeof(gsx_info));
-
-    irq_set_type(gsx_irq_num, IRQ_TYPE_LEVEL_HIGH);
-    ret = request_irq(gsx_irq_num, 0, gsx_irq_handler, "gsx irq", &gsx_info);
-    if ( ret )
-    {
-        iounmap(gsx_reg_base);
-        printk(XENLOG_ERR "Failed to request GSX IRQ\n");
-        return;
-    }
-
-    printk(XENLOG_INFO "Initialized GSX IRQ\n");
 }
 
 /* Dispatch an interrupt */
@@ -450,6 +369,8 @@ void do_IRQ(struct cpu_user_regs *regs, unsigned int irq, int is_fiq)
          * guests.
          */
         vgic_inject_irq(info->d, NULL, info->virq, true);
+        if ( irq == gsx_irq_num )
+            inject_to_gsx_guests(info);
 
         goto out_no_end;
     }
@@ -694,12 +615,18 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
         if ( test_bit(_IRQ_GUEST, &desc->status) )
         {
             struct domain *ad = irq_get_domain(desc);
+            struct irq_guest *ainfo = irq_get_guest_info(desc);
 
             if ( d != ad )
             {
-                printk(XENLOG_G_ERR "IRQ %u is already used by domain %u\n",
-                       irq, ad->domain_id);
-                retval = -EBUSY;
+                if ( irq != gsx_irq_num )
+                {
+                    printk(XENLOG_G_ERR "IRQ %u is already used by domain %u\n",
+                           irq, ad->domain_id);
+                    retval = -EBUSY;
+                }
+                else
+                    add_gsx_guest(d, ainfo);
             }
             else if ( irq_get_guest_info(desc)->virq != virq )
             {
@@ -711,15 +638,15 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
         }
         else
         {
-            if ( opt_rcar3_gsx && irq == gsx_irq_num )
-                retval = add_gsx_domain(d);
-            else
-            {
-                printk(XENLOG_G_ERR "IRQ %u is already used by Xen\n", irq);
-                retval = -EBUSY;
-            }
+            printk(XENLOG_G_ERR "IRQ %u is already used by Xen\n", irq);
+            retval = -EBUSY;
         }
         goto out;
+    }
+    else
+    {
+        if ( irq == gsx_irq_num )
+            init_gsx_guests(d, info);
     }
 
     retval = __setup_irq(desc, 0, action);

--- a/xen/arch/arm/irq.c
+++ b/xen/arch/arm/irq.c
@@ -33,17 +33,11 @@ const unsigned int nr_irqs = NR_IRQS;
 static unsigned int local_irqs_type[NR_LOCAL_IRQS];
 static DEFINE_SPINLOCK(local_irqs_type_lock);
 
-const int gsx_irq_num = 151;
-
-/* Total context count is 8, but the 8th context is always used by host */
-#define GSX_GUESTS_CNT    7
-
 /* Describe an IRQ assigned to a guest */
 struct irq_guest
 {
     struct domain *d;
     unsigned int virq;
-    struct domain *gsx_guests[GSX_GUESTS_CNT];
 };
 
 static void ack_none(struct irq_desc *irq)
@@ -253,76 +247,6 @@ int request_irq(unsigned int irq, unsigned int irqflags,
     return retval;
 }
 
-void remove_gsx_guest(struct domain *d)
-{
-    struct irq_desc *desc = irq_to_desc(gsx_irq_num);
-    struct irq_guest *info;
-    unsigned long flags;
-    int i;
-
-    if ( !desc->action )
-        return;
-
-    spin_lock_irqsave(&desc->lock, flags);
-
-    info = irq_get_guest_info(desc);
-
-    /* clear a slot occupied by gsx guest */
-    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
-    {
-        if ( !info->gsx_guests[i] )
-            continue;
-
-        if ( info->gsx_guests[i] == d )
-        {
-            info->gsx_guests[i] = NULL;
-            printk("Removed GSX guest domain %u\n", d->domain_id);
-            break;
-        }
-    }
-
-    spin_unlock_irqrestore(&desc->lock, flags);
-}
-
-/* called with desc->lock held */
-static void add_gsx_guest(struct domain *d, struct irq_guest *info)
-{
-    int i;
-
-    /* find an empty slot to put gsx guest in it */
-    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
-    {
-        if ( info->gsx_guests[i] )
-           continue;
-
-        info->gsx_guests[i] = d;
-        printk("Added GSX guest domain %u\n", d->domain_id);
-        break;
-    }
-
-    BUG_ON(i == ARRAY_SIZE(info->gsx_guests));
-}
-
-/* called with desc->lock held */
-static void init_gsx_guests(struct domain *d, struct irq_guest *info)
-{
-    memset(info->gsx_guests, 0, sizeof(info->gsx_guests));
-}
-
-/* called with desc->lock held */
-static void inject_to_gsx_guests(struct irq_guest *info)
-{
-    int i;
-
-    /* inject irq to all gsx guests */
-    for ( i = 0; i < ARRAY_SIZE(info->gsx_guests); i++ )
-    {
-        if ( !info->gsx_guests[i] )
-            continue;
-        vgic_inject_irq(info->gsx_guests[i], NULL, info->virq, true);
-    }
-}
-
 /* Dispatch an interrupt */
 void do_IRQ(struct cpu_user_regs *regs, unsigned int irq, int is_fiq)
 {
@@ -369,9 +293,6 @@ void do_IRQ(struct cpu_user_regs *regs, unsigned int irq, int is_fiq)
          * guests.
          */
         vgic_inject_irq(info->d, NULL, info->virq, true);
-        if ( irq == gsx_irq_num )
-            inject_to_gsx_guests(info);
-
         goto out_no_end;
     }
 
@@ -615,18 +536,12 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
         if ( test_bit(_IRQ_GUEST, &desc->status) )
         {
             struct domain *ad = irq_get_domain(desc);
-            struct irq_guest *ainfo = irq_get_guest_info(desc);
 
             if ( d != ad )
             {
-                if ( irq != gsx_irq_num )
-                {
-                    printk(XENLOG_G_ERR "IRQ %u is already used by domain %u\n",
-                           irq, ad->domain_id);
-                    retval = -EBUSY;
-                }
-                else
-                    add_gsx_guest(d, ainfo);
+                printk(XENLOG_G_ERR "IRQ %u is already used by domain %u\n",
+                       irq, ad->domain_id);
+                retval = -EBUSY;
             }
             else if ( irq_get_guest_info(desc)->virq != virq )
             {
@@ -642,11 +557,6 @@ int route_irq_to_guest(struct domain *d, unsigned int virq,
             retval = -EBUSY;
         }
         goto out;
-    }
-    else
-    {
-        if ( irq == gsx_irq_num )
-            init_gsx_guests(d, info);
     }
 
     retval = __setup_irq(desc, 0, action);

--- a/xen/arch/arm/setup.c
+++ b/xen/arch/arm/setup.c
@@ -812,7 +812,6 @@ void asmlinkage __init start_xen(unsigned long boot_phys_offset,
                     "untrusted domains.\n");
 
     init_maintenance_interrupt();
-    init_gsx_interrupt();
     init_timer_interrupt();
 
     timer_init();

--- a/xen/arch/arm/vgic.c
+++ b/xen/arch/arm/vgic.c
@@ -248,9 +248,6 @@ void register_vgic_ops(struct domain *d, const struct vgic_ops *ops)
    d->arch.vgic.handler = ops;
 }
 
-extern const int gsx_irq_num;
-extern void remove_gsx_guest(struct domain *d);
-
 void domain_vgic_free(struct domain *d)
 {
     int i;
@@ -259,9 +256,6 @@ void domain_vgic_free(struct domain *d)
     for ( i = 0; i < (d->arch.vgic.nr_spis); i++ )
     {
         struct pending_irq *p = spi_to_pending(d, i + 32);
-
-        if ( p->irq == gsx_irq_num )
-            remove_gsx_guest(d);
 
         if ( p->desc )
         {

--- a/xen/arch/arm/vgic.c
+++ b/xen/arch/arm/vgic.c
@@ -248,9 +248,8 @@ void register_vgic_ops(struct domain *d, const struct vgic_ops *ops)
    d->arch.vgic.handler = ops;
 }
 
-extern bool opt_rcar3_gsx;
 extern const int gsx_irq_num;
-extern void remove_gsx_domain(struct domain *d);
+extern void remove_gsx_guest(struct domain *d);
 
 void domain_vgic_free(struct domain *d)
 {
@@ -261,8 +260,8 @@ void domain_vgic_free(struct domain *d)
     {
         struct pending_irq *p = spi_to_pending(d, i + 32);
 
-        if ( opt_rcar3_gsx && p->irq == gsx_irq_num )
-            remove_gsx_domain(d);
+        if ( p->irq == gsx_irq_num )
+            remove_gsx_guest(d);
 
         if ( p->desc )
         {

--- a/xen/include/public/arch-arm.h
+++ b/xen/include/public/arch-arm.h
@@ -337,11 +337,6 @@ struct xen_arch_domainconfig {
     /* IN */
     uint32_t nr_spis;
     /*
-     * IN
-     * OSID used by virtual GSX device.
-     */
-    uint8_t vgsx_osid;
-    /*
      * OUT
      * Based on the property clock-frequency in the DT timer node.
      * The property may be present when the bootloader/firmware doesn't


### PR DESCRIPTION
Currently, we have legacy code that is applicable to Gen3 GPU.  It was required because Gen3 GPU have only one IRQ line for all OSIDs, so to inject IRQs and update FW IRQ per-OSID counters, these patches were needed. In the case of Gen5, this code is not needed because the new generation has dedicated IRQs for every OSID. Moreover, it may lead to potential issues, as these patches contain hardcoded values for GPU regions and for IRQ (151). Also, for Gen5 this memory region overlaps with other real device - SMMU pere (used for eMMC) and the existing code remaps it to Xen. Thus, this redundant, legacy code should definitely be reverted.